### PR TITLE
refs #TECH: force aray_filter to use a callable function that return boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 * Require booleans in `if`, `elseif`, ternary operator, after `!`, and on both sides of `&&` and `||`.
 * Functions `in_array` and `array_search` must be called with third parameter `$strict` set to `true` to search values with matching types only.
+* Function `array_filter` must be called with second parameter (callable function) taht should return `bool`.
 * Variables assigned in `while` loop condition and `for` loop initial assignment cannot be used after the loop.
 * Types in `switch` condition and `case` value must match. PHP compares them loosely by default and that can lead to unexpected results.
 * Statically declared methods are called statically.

--- a/rules.neon
+++ b/rules.neon
@@ -3,6 +3,11 @@ parameters:
 
 services:
 	-
+		class: PHPStan\Rules\ArrayFunction\ArrayFilterFunctionBooleanRule
+		tags:
+			- phpstan.rules.rule
+
+	-
 		class: PHPStan\Rules\BooleansInConditions\BooleanInBooleanAndRule
 		tags:
 			- phpstan.rules.rule

--- a/src/Rules/ArrayFunction/ArrayFilterFunctionBooleanRule.php
+++ b/src/Rules/ArrayFunction/ArrayFilterFunctionBooleanRule.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\ArrayFunction;
+
+class ArrayFilterFunctionBooleanRule implements \PHPStan\Rules\Rule
+{
+
+	/** @var int[] */
+	private $functionArguments = [
+		'array_filter' => 1,
+	];
+
+	/** @var \PHPStan\Broker\Broker */
+	private $broker;
+
+	public function __construct(\PHPStan\Broker\Broker $broker)
+	{
+		$this->broker = $broker;
+	}
+
+	public function getNodeType(): string
+	{
+		return \PhpParser\Node\Expr\FuncCall::class;
+	}
+
+	/**
+	 * @param \PhpParser\Node\Expr\FuncCall $node
+	 * @param \PHPStan\Analyser\Scope $scope
+	 * @return string[] errors
+	 */
+	public function processNode(\PhpParser\Node $node, \PHPStan\Analyser\Scope $scope): array
+	{
+		if (!$node->name instanceof \PhpParser\Node\Name) {
+			return [];
+		}
+
+		$functionName = $this->broker->resolveFunctionName($node->name, $scope);
+		if ($functionName === null) {
+			return [];
+		}
+
+		$functionName = strtolower($functionName);
+		if (!array_key_exists($functionName, $this->functionArguments)) {
+			return [];
+		}
+
+		$argumentPosition = $this->functionArguments[$functionName];
+		$message = sprintf('Call to function %s() requires parameter #%d to be callable.', $functionName, $argumentPosition + 1);
+		if (!array_key_exists($argumentPosition, $node->args)) {
+			return [$message];
+		}
+
+		if ($node->args[$argumentPosition]->value instanceof \PhpParser\Node\Expr\Array_) {
+			$this->getMethodFromArray($node->args[$argumentPosition]->value->items, $scope);
+		}
+
+		$message = sprintf('Call to function %s() requires parameter #%d to be callable.', $functionName, $argumentPosition + 1);
+		if (!$argumentType->isCallable()) {
+			return [$message];
+		}
+
+		$returnType = $scope->getFunctionType($node->args[$argumentPosition]->value->getReturnType(), false, false);
+		$message = sprintf('Call to function %s() requires parameter #%d to return boolean.', $functionName, $argumentPosition + 1);
+		if (!$returnType instanceof \PHPStan\Type\BooleanType) {
+			return [$message];
+		}
+
+		return [];
+	}
+
+}

--- a/tests/Rules/ArrayFunction/ArrayFilterFunctionBooleanRuleTest.php
+++ b/tests/Rules/ArrayFunction/ArrayFilterFunctionBooleanRuleTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\ArrayFunction;
+
+use PHPStan\Rules\Rule;
+
+class ArrayFilterFunctionBooleanRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new ArrayFilterFunctionBooleanRule($this->createBroker());
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/array-filter.php'], [
+			[
+				'Call to function array_filter() requires parameter #2 to be callable.',
+				5,
+			],
+			[
+				'Call to function array_filter() requires parameter #2 to return boolean.',
+				6,
+			],
+			[
+				'Call to function array_filter() requires parameter #2 to return boolean.',
+				8,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/ArrayFunction/data/array-filter.php
+++ b/tests/Rules/ArrayFunction/data/array-filter.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ArrayFunction;
+
+array_filter([1, 2, 3]);
+array_filter([1, 2, 3], function (int $a): string { return 'a'; });
+array_filter([1, 2, 3], function (int $a): bool { return true; });
+array_filter([1, 2, 3], function (int $a): ?bool { return null; });
+Array_Filter([1, 2, 3], function (int $a): bool { return true; });


### PR DESCRIPTION
This is a WIP since there are some use cases that are not accepted, eg:

```
array_filter([1, 2, 3], "\PHPStan\Rules\ArrayFunction\data\odd");
array_filter([1, 2, 3], [$filter, "anOdd"]);
var_dump(array_filter([1, 2, 3], [Filter::class, "anEven"]));
```
that should be fixed once https://github.com/phpstan/phpstan/pull/716 will be merged