### PR TITLE
Strict iterator_to_array, do not overwite duplicate keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   * `array_search` (3rd parameter)
   * `array_keys` (3rd parameter; only if the 2nd parameter `$search_value` is provided)
   * `base64_decode` (2nd parameter)
+* Function `iterator_to_array` must be called with second parameter `$use_keys` set to `false` to not overwite duplicate iterator keys in the result.
 * Variables assigned in `while` loop condition and `for` loop initial assignment cannot be used after the loop.
 * Types in `switch` condition and `case` value must match. PHP compares them loosely by default and that can lead to unexpected results.
 * Statically declared methods are called statically.

--- a/tests/Rules/StrictCalls/StrictFunctionCallsRuleTest.php
+++ b/tests/Rules/StrictCalls/StrictFunctionCallsRuleTest.php
@@ -67,6 +67,14 @@ class StrictFunctionCallsRuleTest extends \PHPStan\Testing\RuleTestCase
 				'Call to function array_keys() requires parameter #3 to be true.',
 				31,
 			],
+			[
+				'Call to function iterator_to_array() requires parameter #2 to be false.',
+				34,
+			],
+			[
+				'Call to function iterator_to_array() requires parameter #2 to be set.',
+				35,
+			],
 		]);
 	}
 

--- a/tests/Rules/StrictCalls/data/strict-calls.php
+++ b/tests/Rules/StrictCalls/data/strict-calls.php
@@ -29,3 +29,7 @@ $dynamicCall();
 /** @var bool $bool */
 $bool = doFoo();
 array_keys([1, 2, 3], 1, $bool);
+
+iterator_to_array(new \ArrayIterator([]), false);
+iterator_to_array(new \ArrayIterator([]), true);
+iterator_to_array(new \ArrayIterator([]));


### PR DESCRIPTION
This has shot us in a foot a couple times, especially when `yield`ing `from` an inner generator inside a generator.