### PR TITLE
Add rules for operands in arithmetic operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [PHPStan](https://github.com/phpstan/phpstan) focuses on finding bugs in your code. But in PHP there's a lot of leeway in how stuff can be written. This repository contains additional rules that revolve around strictly and strongly typed code with no loose casting for those who want additional safety in extremely defensive programming:
 
 * Require booleans in `if`, `elseif`, ternary operator, after `!`, and on both sides of `&&` and `||`.
+* Require numeric operands or arrays in `+` and numeric operands in `-`/`*`/`/`/`**`/`%`.
 * These functions contain a `$strict` parameter for better type safety, it must be set to `true`:
   * `in_array` (3rd parameter)
   * `array_search` (3rd parameter)

--- a/rules.neon
+++ b/rules.neon
@@ -17,6 +17,12 @@ rules:
 	- PHPStan\Rules\Methods\MissingMethodParameterTypehintRule
 	- PHPStan\Rules\Methods\MissingMethodReturnTypehintRule
 	- PHPStan\Rules\Methods\WrongCaseOfInheritedMethodRule
+	- PHPStan\Rules\Operators\OperandsInArithmeticAddition
+	- PHPStan\Rules\Operators\OperandsInArithmeticDivision
+	- PHPStan\Rules\Operators\OperandsInArithmeticExponentiation
+	- PHPStan\Rules\Operators\OperandsInArithmeticModulo
+	- PHPStan\Rules\Operators\OperandsInArithmeticMultiplication
+	- PHPStan\Rules\Operators\OperandsInArithmeticSubtraction
 	- PHPStan\Rules\Properties\MissingPropertyTypehintRule
 	- PHPStan\Rules\StrictCalls\DynamicCallOnStaticMethodsRule
 	- PHPStan\Rules\StrictCalls\StrictFunctionCallsRule

--- a/src/Rules/Operators/OperandsInArithmeticAddition.php
+++ b/src/Rules/Operators/OperandsInArithmeticAddition.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\MixedType;
+
+class OperandsInArithmeticAddition implements \PHPStan\Rules\Rule
+{
+
+	public function getNodeType(): string
+	{
+		return \PhpParser\Node\Expr\BinaryOp\Plus::class;
+	}
+
+	/**
+	 * @param \PhpParser\Node\Expr\BinaryOp\BooleanAnd $node
+	 * @param \PHPStan\Analyser\Scope $scope
+	 * @return string[] errors
+	 */
+	public function processNode(\PhpParser\Node $node, \PHPStan\Analyser\Scope $scope): array
+	{
+		$leftType = $scope->getType($node->left);
+		$rightType = $scope->getType($node->right);
+
+		if (OperatorRuleHelper::isValidForArithmeticOperation($leftType, $rightType)) {
+			return [];
+		}
+
+		$mixedArrayType = new ArrayType(new MixedType(), new MixedType());
+
+		if ($mixedArrayType->isSuperTypeOf($leftType)->yes() && $mixedArrayType->isSuperTypeOf($rightType)->yes()) {
+			return [];
+		}
+
+		return ['Only numeric types or arrays are allowed in arithmetic addition.'];
+	}
+
+}

--- a/src/Rules/Operators/OperandsInArithmeticDivision.php
+++ b/src/Rules/Operators/OperandsInArithmeticDivision.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+class OperandsInArithmeticDivision implements \PHPStan\Rules\Rule
+{
+
+	public function getNodeType(): string
+	{
+		return \PhpParser\Node\Expr\BinaryOp\Div::class;
+	}
+
+	/**
+	 * @param \PhpParser\Node\Expr\BinaryOp\BooleanAnd $node
+	 * @param \PHPStan\Analyser\Scope $scope
+	 * @return string[] errors
+	 */
+	public function processNode(\PhpParser\Node $node, \PHPStan\Analyser\Scope $scope): array
+	{
+		$leftType = $scope->getType($node->left);
+		$rightType = $scope->getType($node->right);
+
+		if (OperatorRuleHelper::isValidForArithmeticOperation($leftType, $rightType)) {
+			return [];
+		}
+
+		return ['Only numeric types are allowed in arithmetic division.'];
+	}
+
+}

--- a/src/Rules/Operators/OperandsInArithmeticExponentiation.php
+++ b/src/Rules/Operators/OperandsInArithmeticExponentiation.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+class OperandsInArithmeticExponentiation implements \PHPStan\Rules\Rule
+{
+
+	public function getNodeType(): string
+	{
+		return \PhpParser\Node\Expr\BinaryOp\Pow::class;
+	}
+
+	/**
+	 * @param \PhpParser\Node\Expr\BinaryOp\BooleanAnd $node
+	 * @param \PHPStan\Analyser\Scope $scope
+	 * @return string[] errors
+	 */
+	public function processNode(\PhpParser\Node $node, \PHPStan\Analyser\Scope $scope): array
+	{
+		$leftType = $scope->getType($node->left);
+		$rightType = $scope->getType($node->right);
+
+		if (OperatorRuleHelper::isValidForArithmeticOperation($leftType, $rightType)) {
+			return [];
+		}
+
+		return ['Only numeric types are allowed in arithmetic exponentiation.'];
+	}
+
+}

--- a/src/Rules/Operators/OperandsInArithmeticModulo.php
+++ b/src/Rules/Operators/OperandsInArithmeticModulo.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+class OperandsInArithmeticModulo implements \PHPStan\Rules\Rule
+{
+
+	public function getNodeType(): string
+	{
+		return \PhpParser\Node\Expr\BinaryOp\Mod::class;
+	}
+
+	/**
+	 * @param \PhpParser\Node\Expr\BinaryOp\BooleanAnd $node
+	 * @param \PHPStan\Analyser\Scope $scope
+	 * @return string[] errors
+	 */
+	public function processNode(\PhpParser\Node $node, \PHPStan\Analyser\Scope $scope): array
+	{
+		$leftType = $scope->getType($node->left);
+		$rightType = $scope->getType($node->right);
+
+		if (OperatorRuleHelper::isValidForArithmeticOperation($leftType, $rightType)) {
+			return [];
+		}
+
+		return ['Only numeric types are allowed in arithmetic modulo.'];
+	}
+
+}

--- a/src/Rules/Operators/OperandsInArithmeticMultiplication.php
+++ b/src/Rules/Operators/OperandsInArithmeticMultiplication.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+class OperandsInArithmeticMultiplication implements \PHPStan\Rules\Rule
+{
+
+	public function getNodeType(): string
+	{
+		return \PhpParser\Node\Expr\BinaryOp\Mul::class;
+	}
+
+	/**
+	 * @param \PhpParser\Node\Expr\BinaryOp\BooleanAnd $node
+	 * @param \PHPStan\Analyser\Scope $scope
+	 * @return string[] errors
+	 */
+	public function processNode(\PhpParser\Node $node, \PHPStan\Analyser\Scope $scope): array
+	{
+		$leftType = $scope->getType($node->left);
+		$rightType = $scope->getType($node->right);
+
+		if (OperatorRuleHelper::isValidForArithmeticOperation($leftType, $rightType)) {
+			return [];
+		}
+
+		return ['Only numeric types are allowed in arithmetic multiplication.'];
+	}
+
+}

--- a/src/Rules/Operators/OperandsInArithmeticSubtraction.php
+++ b/src/Rules/Operators/OperandsInArithmeticSubtraction.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+class OperandsInArithmeticSubtraction implements \PHPStan\Rules\Rule
+{
+
+	public function getNodeType(): string
+	{
+		return \PhpParser\Node\Expr\BinaryOp\Minus::class;
+	}
+
+	/**
+	 * @param \PhpParser\Node\Expr\BinaryOp\BooleanAnd $node
+	 * @param \PHPStan\Analyser\Scope $scope
+	 * @return string[] errors
+	 */
+	public function processNode(\PhpParser\Node $node, \PHPStan\Analyser\Scope $scope): array
+	{
+		$leftType = $scope->getType($node->left);
+		$rightType = $scope->getType($node->right);
+
+		if (OperatorRuleHelper::isValidForArithmeticOperation($leftType, $rightType)) {
+			return [];
+		}
+
+		return ['Only numeric types are allowed in arithmetic subtraction.'];
+	}
+
+}

--- a/src/Rules/Operators/OperatorRuleHelper.php
+++ b/src/Rules/Operators/OperatorRuleHelper.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PHPStan\Type\FloatType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+
+class OperatorRuleHelper
+{
+
+	public static function isValidForArithmeticOperation(Type $leftType, Type $rightType): bool
+	{
+		$acceptedType = new UnionType([new IntegerType(), new FloatType()]);
+
+		return $acceptedType->isSuperTypeOf($leftType)->yes() && $acceptedType->isSuperTypeOf($rightType)->yes();
+	}
+
+}

--- a/tests/Rules/Operators/OperandsInArithmeticAdditionTest.php
+++ b/tests/Rules/Operators/OperandsInArithmeticAdditionTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PHPStan\Rules\Rule;
+
+class OperandsInArithmeticAdditionTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new OperandsInArithmeticAddition();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/operators.php'], [
+			[
+				'Only numeric types or arrays are allowed in arithmetic addition.',
+				25,
+			],
+			[
+				'Only numeric types or arrays are allowed in arithmetic addition.',
+				26,
+			],
+			[
+				'Only numeric types or arrays are allowed in arithmetic addition.',
+				27,
+			],
+			[
+				'Only numeric types or arrays are allowed in arithmetic addition.',
+				28,
+			],
+			[
+				'Only numeric types or arrays are allowed in arithmetic addition.',
+				29,
+			],
+			[
+				'Only numeric types or arrays are allowed in arithmetic addition.',
+				29,
+			],
+			[
+				'Only numeric types or arrays are allowed in arithmetic addition.',
+				30,
+			],
+			[
+				'Only numeric types or arrays are allowed in arithmetic addition.',
+				30,
+			],
+			[
+				'Only numeric types or arrays are allowed in arithmetic addition.',
+				30,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/Operators/OperandsInArithmeticDivisionTest.php
+++ b/tests/Rules/Operators/OperandsInArithmeticDivisionTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PHPStan\Rules\Rule;
+
+class OperandsInArithmeticDivisionTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new OperandsInArithmeticDivision();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/operators.php'], [
+			[
+				'Only numeric types are allowed in arithmetic division.',
+				64,
+			],
+			[
+				'Only numeric types are allowed in arithmetic division.',
+				65,
+			],
+			[
+				'Only numeric types are allowed in arithmetic division.',
+				66,
+			],
+			[
+				'Only numeric types are allowed in arithmetic division.',
+				67,
+			],
+			[
+				'Only numeric types are allowed in arithmetic division.',
+				68,
+			],
+			[
+				'Only numeric types are allowed in arithmetic division.',
+				68,
+			],
+			[
+				'Only numeric types are allowed in arithmetic division.',
+				69,
+			],
+			[
+				'Only numeric types are allowed in arithmetic division.',
+				69,
+			],
+			[
+				'Only numeric types are allowed in arithmetic division.',
+				69,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/Operators/OperandsInArithmeticExponentiationTest.php
+++ b/tests/Rules/Operators/OperandsInArithmeticExponentiationTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PHPStan\Rules\Rule;
+
+class OperandsInArithmeticExponentiationTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new OperandsInArithmeticExponentiation();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/operators.php'], [
+			[
+				'Only numeric types are allowed in arithmetic exponentiation.',
+				77,
+			],
+			[
+				'Only numeric types are allowed in arithmetic exponentiation.',
+				78,
+			],
+			[
+				'Only numeric types are allowed in arithmetic exponentiation.',
+				79,
+			],
+			[
+				'Only numeric types are allowed in arithmetic exponentiation.',
+				80,
+			],
+			[
+				'Only numeric types are allowed in arithmetic exponentiation.',
+				81,
+			],
+			[
+				'Only numeric types are allowed in arithmetic exponentiation.',
+				82,
+			],
+			[
+				'Only numeric types are allowed in arithmetic exponentiation.',
+				82,
+			],
+			[
+				'Only numeric types are allowed in arithmetic exponentiation.',
+				82,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/Operators/OperandsInArithmeticModuloTest.php
+++ b/tests/Rules/Operators/OperandsInArithmeticModuloTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PHPStan\Rules\Rule;
+
+class OperandsInArithmeticModuloTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new OperandsInArithmeticModulo();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/operators.php'], [
+			[
+				'Only numeric types are allowed in arithmetic modulo.',
+				90,
+			],
+			[
+				'Only numeric types are allowed in arithmetic modulo.',
+				91,
+			],
+			[
+				'Only numeric types are allowed in arithmetic modulo.',
+				92,
+			],
+			[
+				'Only numeric types are allowed in arithmetic modulo.',
+				93,
+			],
+			[
+				'Only numeric types are allowed in arithmetic modulo.',
+				94,
+			],
+			[
+				'Only numeric types are allowed in arithmetic modulo.',
+				94,
+			],
+			[
+				'Only numeric types are allowed in arithmetic modulo.',
+				95,
+			],
+			[
+				'Only numeric types are allowed in arithmetic modulo.',
+				95,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/Operators/OperandsInArithmeticMultiplicationTest.php
+++ b/tests/Rules/Operators/OperandsInArithmeticMultiplicationTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PHPStan\Rules\Rule;
+
+class OperandsInArithmeticMultiplicationTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new OperandsInArithmeticMultiplication();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/operators.php'], [
+			[
+				'Only numeric types are allowed in arithmetic multiplication.',
+				51,
+			],
+			[
+				'Only numeric types are allowed in arithmetic multiplication.',
+				52,
+			],
+			[
+				'Only numeric types are allowed in arithmetic multiplication.',
+				53,
+			],
+			[
+				'Only numeric types are allowed in arithmetic multiplication.',
+				54,
+			],
+			[
+				'Only numeric types are allowed in arithmetic multiplication.',
+				55,
+			],
+			[
+				'Only numeric types are allowed in arithmetic multiplication.',
+				55,
+			],
+			[
+				'Only numeric types are allowed in arithmetic multiplication.',
+				56,
+			],
+			[
+				'Only numeric types are allowed in arithmetic multiplication.',
+				56,
+			],
+			[
+				'Only numeric types are allowed in arithmetic multiplication.',
+				56,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/Operators/OperandsInArithmeticSubtractionTest.php
+++ b/tests/Rules/Operators/OperandsInArithmeticSubtractionTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PHPStan\Rules\Rule;
+
+class OperandsInArithmeticSubtractionTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new OperandsInArithmeticSubtraction();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/operators.php'], [
+			[
+				'Only numeric types are allowed in arithmetic subtraction.',
+				38,
+			],
+			[
+				'Only numeric types are allowed in arithmetic subtraction.',
+				39,
+			],
+			[
+				'Only numeric types are allowed in arithmetic subtraction.',
+				40,
+			],
+			[
+				'Only numeric types are allowed in arithmetic subtraction.',
+				41,
+			],
+			[
+				'Only numeric types are allowed in arithmetic subtraction.',
+				42,
+			],
+			[
+				'Only numeric types are allowed in arithmetic subtraction.',
+				42,
+			],
+			[
+				'Only numeric types are allowed in arithmetic subtraction.',
+				43,
+			],
+			[
+				'Only numeric types are allowed in arithmetic subtraction.',
+				43,
+			],
+			[
+				'Only numeric types are allowed in arithmetic subtraction.',
+				43,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/Operators/data/operators.php
+++ b/tests/Rules/Operators/data/operators.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Operators;
+
+use stdClass;
+
+$int = 123;
+$float = 123.456;
+$array = [];
+$string = '123';
+$object = new stdClass();
+$null = null;
+
+/** @var int|float $intOrFloat */
+$intOrFloat = foo();
+
+$int + $int;
+$int + $float;
+$float + $int;
+$float + $float;
+$int + $float + $int;
+$intOrFloat + $int;
+$array + $array;
+$array + $array + $array;
+$int + $string;
+$int + $array;
+$int + $object;
+$int + $null;
+$int + $float + $string + $null;
+$array + $float + $array + $int;
+
+$int - $int;
+$int - $float;
+$float - $int;
+$float - $float;
+$int - $float - $int;
+$intOrFloat - $int;
+$int - $string;
+$int - $array;
+$int - $object;
+$int - $null;
+$int - $float - $string - $null;
+$array - $float - $array - $int;
+
+$int * $int;
+$int * $float;
+$float * $int;
+$float * $float;
+$int * $float * $int;
+$intOrFloat * $int;
+$int * $string;
+$int * $array;
+$int * $object;
+$int * $null;
+$int * $float * $string * $null;
+$array * $float * $array * $int;
+
+$int / $int;
+$int / $float;
+$float / $int;
+$float / $float;
+$int / $float / $int;
+$intOrFloat / $int;
+$int / $string;
+$int / $array;
+$int / $object;
+$int / $null;
+$int / $float / $string / $null;
+$array / $float / $array / $int;
+
+$int ** $int;
+$int ** $float;
+$float ** $int;
+$float ** $float;
+$int ** $float ** $int;
+$intOrFloat ** $int;
+$int ** $string;
+$int ** $array;
+$int ** $object;
+$int ** $null;
+$int ** $float ** $string ** $null;
+$array ** $float ** $array ** $int;
+
+$int % $int;
+$int % $float;
+$float % $int;
+$float % $float;
+$int % $float % $int;
+$intOrFloat % $int;
+$int % $string;
+$int % $array;
+$int % $object;
+$int % $null;
+$int % $float % $string % $null;
+$array % $float % $array % $int;


### PR DESCRIPTION
* Require array or int/float operands in `+`.
* Require int/float operands in `-`/`*`/`/`/`**`/`%`.