### PR TITLE
Added last method rules to rules configuration, added property typehint check

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -15,6 +15,7 @@ rules:
 	- PHPStan\Rules\DisallowedConstructs\DisallowedEmptyRule
 	- PHPStan\Rules\DisallowedConstructs\DisallowedImplicitArrayCreationRule
 	- PHPStan\Rules\Methods\MissingMethodParameterTypehintRule
+	- PHPStan\Rules\Methods\MissingMethodReturnTypehintRule
 	- PHPStan\Rules\Methods\WrongCaseOfInheritedMethodRule
 	- PHPStan\Rules\StrictCalls\DynamicCallOnStaticMethodsRule
 	- PHPStan\Rules\StrictCalls\StrictFunctionCallsRule

--- a/rules.neon
+++ b/rules.neon
@@ -14,6 +14,7 @@ rules:
 	- PHPStan\Rules\BooleansInConditions\BooleanInTernaryOperatorRule
 	- PHPStan\Rules\DisallowedConstructs\DisallowedEmptyRule
 	- PHPStan\Rules\DisallowedConstructs\DisallowedImplicitArrayCreationRule
+	- PHPStan\Rules\Methods\MissingMethodParameterTypehintRule
 	- PHPStan\Rules\Methods\WrongCaseOfInheritedMethodRule
 	- PHPStan\Rules\StrictCalls\DynamicCallOnStaticMethodsRule
 	- PHPStan\Rules\StrictCalls\StrictFunctionCallsRule

--- a/rules.neon
+++ b/rules.neon
@@ -17,6 +17,7 @@ rules:
 	- PHPStan\Rules\Methods\MissingMethodParameterTypehintRule
 	- PHPStan\Rules\Methods\MissingMethodReturnTypehintRule
 	- PHPStan\Rules\Methods\WrongCaseOfInheritedMethodRule
+	- PHPStan\Rules\Properties\MissingPropertyTypehintRule
 	- PHPStan\Rules\StrictCalls\DynamicCallOnStaticMethodsRule
 	- PHPStan\Rules\StrictCalls\StrictFunctionCallsRule
 	- PHPStan\Rules\SwitchConditions\MatchingTypeInSwitchCaseConditionRule

--- a/src/Rules/Properties/MissingPropertyTypehintRule.php
+++ b/src/Rules/Properties/MissingPropertyTypehintRule.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Properties;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\PropertyReflection;
+use PHPStan\Type\MixedType;
+
+final class MissingPropertyTypehintRule implements \PHPStan\Rules\Rule
+{
+
+	/**
+	 * @return string Class implementing \PhpParser\Node
+	 */
+	public function getNodeType(): string
+	{
+		return \PhpParser\Node\Stmt\PropertyProperty::class;
+	}
+
+	/**
+	 * @param \PhpParser\Node\Stmt\PropertyProperty $node
+	 * @param \PHPStan\Analyser\Scope $scope
+	 *
+	 * @return string[] errors
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!$scope->isInClass()) {
+			throw new \PHPStan\ShouldNotHappenException();
+		}
+
+		$propertyReflection = $scope->getClassReflection()->getNativeProperty($node->name);
+
+		$messages = [];
+
+		$message = $this->checkPropertyType($node->name, $propertyReflection);
+		if ($message !== null) {
+			$messages[] = $message;
+		}
+
+		return $messages;
+	}
+
+	private function checkPropertyType(string $propertyName, PropertyReflection $propertyReflection): ?string
+	{
+		$returnType = $propertyReflection->getType();
+
+		if ($returnType instanceof MixedType && !$returnType->isExplicitMixed()) {
+			return sprintf(
+				'Property %s::$%s has no typehint specified',
+				$propertyReflection->getDeclaringClass()->getName(),
+				$propertyName
+			);
+		}
+
+		return null;
+	}
+
+}

--- a/tests/Rules/Properties/MissingPropertyTypehintRuleTest.php
+++ b/tests/Rules/Properties/MissingPropertyTypehintRuleTest.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Properties;
+
+class MissingPropertyTypehintRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): \PHPStan\Rules\Rule
+	{
+		return new MissingPropertyTypehintRule();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/missing-property-typehint.php'], [
+			[
+				'Property MissingPropertyTypehint\MyClass::$prop1 has no typehint specified',
+				7,
+			],
+			[
+				'Property MissingPropertyTypehint\MyClass::$prop2 has no typehint specified',
+				9,
+			],
+			[
+				'Property MissingPropertyTypehint\MyClass::$prop3 has no typehint specified',
+				14,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/Properties/data/missing-property-typehint.php
+++ b/tests/Rules/Properties/data/missing-property-typehint.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace MissingPropertyTypehint;
+
+class MyClass
+{
+	private $prop1;
+
+	protected $prop2 = null;
+
+	/**
+	 * @var
+	 */
+	public $prop3;
+}
+
+class ChildClass extends MyClass
+{
+	/**
+	 * @var int
+	 */
+	protected $prop1;
+
+	/**
+	 * @var null
+	 */
+	protected $prop2;
+}


### PR DESCRIPTION
Hi.

1) Previously I forgot to register method rules to rules.neon, so they are not activated not.
2) Added new rule property typehint check - whether every property in class has defined typehint.

I can split changes if some changes to new property rule needed of course.