### PR TITLE
Add rules for operand in pre/post-inc/decrement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 * Require booleans in `if`, `elseif`, ternary operator, after `!`, and on both sides of `&&` and `||`.
 * Require numeric operands or arrays in `+` and numeric operands in `-`/`*`/`/`/`**`/`%`.
+* Require numeric operand in `$var++`, `$var--`, `++$var`and `--$var`.
 * These functions contain a `$strict` parameter for better type safety, it must be set to `true`:
   * `in_array` (3rd parameter)
   * `array_search` (3rd parameter)

--- a/rules.neon
+++ b/rules.neon
@@ -17,6 +17,10 @@ rules:
 	- PHPStan\Rules\Methods\MissingMethodParameterTypehintRule
 	- PHPStan\Rules\Methods\MissingMethodReturnTypehintRule
 	- PHPStan\Rules\Methods\WrongCaseOfInheritedMethodRule
+	- PHPStan\Rules\Operators\OperandInArithmeticPostDecrementRule
+	- PHPStan\Rules\Operators\OperandInArithmeticPostIncrementRule
+	- PHPStan\Rules\Operators\OperandInArithmeticPreDecrementRule
+	- PHPStan\Rules\Operators\OperandInArithmeticPreIncrementRule
 	- PHPStan\Rules\Operators\OperandsInArithmeticAdditionRule
 	- PHPStan\Rules\Operators\OperandsInArithmeticDivisionRule
 	- PHPStan\Rules\Operators\OperandsInArithmeticExponentiationRule

--- a/src/Rules/Operators/OperandInArithmeticIncrementOrDecrementRule.php
+++ b/src/Rules/Operators/OperandInArithmeticIncrementOrDecrementRule.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Type\VerbosityLevel;
+
+abstract class OperandInArithmeticIncrementOrDecrementRule implements Rule
+{
+
+	/** @var OperatorRuleHelper */
+	private $helper;
+
+	public function __construct(OperatorRuleHelper $helper)
+	{
+		$this->helper = $helper;
+	}
+
+	/**
+	 * @param \PhpParser\Node\Expr\PreInc|\PhpParser\Node\Expr\PreDec|\PhpParser\Node\Expr\PostInc|\PhpParser\Node\Expr\PostDec $node
+	 * @param \PHPStan\Analyser\Scope $scope
+	 * @return string[] errors
+	 */
+	public function processNode(\PhpParser\Node $node, \PHPStan\Analyser\Scope $scope): array
+	{
+		$messages = [];
+		$varType = $scope->getType($node->var);
+
+		if (!$this->helper->isValidForIncrementOrDecrement($scope, $node->var)) {
+			$messages[] = sprintf(
+				'Only numeric types are allowed in %s, %s given.',
+				$this->describeOperation(),
+				$varType->describe(VerbosityLevel::typeOnly())
+			);
+		}
+
+		return $messages;
+	}
+
+	abstract protected function describeOperation(): string;
+
+}

--- a/src/Rules/Operators/OperandInArithmeticPostDecrementRule.php
+++ b/src/Rules/Operators/OperandInArithmeticPostDecrementRule.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+class OperandInArithmeticPostDecrementRule extends OperandInArithmeticIncrementOrDecrementRule
+{
+
+	public function getNodeType(): string
+	{
+		return \PhpParser\Node\Expr\PostDec::class;
+	}
+
+	protected function describeOperation(): string
+	{
+		return 'post-decrement';
+	}
+
+}

--- a/src/Rules/Operators/OperandInArithmeticPostIncrementRule.php
+++ b/src/Rules/Operators/OperandInArithmeticPostIncrementRule.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+class OperandInArithmeticPostIncrementRule extends OperandInArithmeticIncrementOrDecrementRule
+{
+
+	public function getNodeType(): string
+	{
+		return \PhpParser\Node\Expr\PostInc::class;
+	}
+
+	protected function describeOperation(): string
+	{
+		return 'post-increment';
+	}
+
+}

--- a/src/Rules/Operators/OperandInArithmeticPreDecrementRule.php
+++ b/src/Rules/Operators/OperandInArithmeticPreDecrementRule.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+class OperandInArithmeticPreDecrementRule extends OperandInArithmeticIncrementOrDecrementRule
+{
+
+	public function getNodeType(): string
+	{
+		return \PhpParser\Node\Expr\PreDec::class;
+	}
+
+	protected function describeOperation(): string
+	{
+		return 'pre-decrement';
+	}
+
+}

--- a/src/Rules/Operators/OperandInArithmeticPreIncrementRule.php
+++ b/src/Rules/Operators/OperandInArithmeticPreIncrementRule.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+class OperandInArithmeticPreIncrementRule extends OperandInArithmeticIncrementOrDecrementRule
+{
+
+	public function getNodeType(): string
+	{
+		return \PhpParser\Node\Expr\PreInc::class;
+	}
+
+	protected function describeOperation(): string
+	{
+		return 'pre-increment';
+	}
+
+}

--- a/src/Rules/Operators/OperatorRuleHelper.php
+++ b/src/Rules/Operators/OperatorRuleHelper.php
@@ -30,21 +30,37 @@ class OperatorRuleHelper
 			return true;
 		}
 
+		// already reported by PHPStan core
 		if ($type->toNumber() instanceof ErrorType) {
 			return true;
 		}
 
+		return $this->isSubtypeOfNumber($scope, $expr);
+	}
+
+	public function isValidForIncrementOrDecrement(Scope $scope, Expr $expr): bool
+	{
+		$type = $scope->getType($expr);
+		if ($type instanceof MixedType) {
+			return true;
+		}
+
+		return $this->isSubtypeOfNumber($scope, $expr);
+	}
+
+	private function isSubtypeOfNumber(Scope $scope, Expr $expr): bool
+	{
 		$acceptedType = new UnionType([new IntegerType(), new FloatType()]);
 
-		$typeToCheck = $this->ruleLevelHelper->findTypeToCheck(
+		$type = $this->ruleLevelHelper->findTypeToCheck(
 			$scope,
 			$expr,
 			'',
 			function (Type $type) use ($acceptedType): bool {
 				return $acceptedType->isSuperTypeOf($type)->yes();
 			}
-		);
-		$type = $typeToCheck->getType();
+		)->getType();
+
 		if ($type instanceof ErrorType) {
 			return true;
 		}

--- a/tests/Rules/Operators/OperandInArithmeticIncrementOrDecrementRuleTest.php
+++ b/tests/Rules/Operators/OperandInArithmeticIncrementOrDecrementRuleTest.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleLevelHelper;
+
+abstract class OperandInArithmeticIncrementOrDecrementRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return $this->createRule(
+			new OperatorRuleHelper(
+				new RuleLevelHelper($this->createBroker(), true, false, true)
+			)
+		);
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/increment-decrement.php'], $this->getExpectedErrors());
+	}
+
+	abstract protected function createRule(OperatorRuleHelper $helper): Rule;
+
+	/**
+	 * @return mixed[][]
+	 */
+	abstract protected function getExpectedErrors(): array;
+
+}

--- a/tests/Rules/Operators/OperandInArithmeticPostDecrementRuleTest.php
+++ b/tests/Rules/Operators/OperandInArithmeticPostDecrementRuleTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PHPStan\Rules\Rule;
+
+class OperandInArithmeticPostDecrementRuleTest extends OperandInArithmeticIncrementOrDecrementRuleTest
+{
+
+	protected function createRule(OperatorRuleHelper $helper): Rule
+	{
+		return new OperandInArithmeticPostDecrementRule($helper);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function getExpectedErrors(): array
+	{
+		return [
+			[
+				'Only numeric types are allowed in post-decrement, false given.',
+				21,
+			],
+			[
+				'Only numeric types are allowed in post-decrement, string given.',
+				22,
+			],
+			[
+				'Only numeric types are allowed in post-decrement, null given.',
+				23,
+			],
+			[
+				'Only numeric types are allowed in post-decrement, stdClass given.',
+				24,
+			],
+			[
+				'Only numeric types are allowed in post-decrement, int|stdClass|string given.',
+				26,
+			],
+		];
+	}
+
+}

--- a/tests/Rules/Operators/OperandInArithmeticPostIncrementRuleTest.php
+++ b/tests/Rules/Operators/OperandInArithmeticPostIncrementRuleTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PHPStan\Rules\Rule;
+
+class OperandInArithmeticPostIncrementRuleTest extends OperandInArithmeticIncrementOrDecrementRuleTest
+{
+
+	protected function createRule(OperatorRuleHelper $helper): Rule
+	{
+		return new OperandInArithmeticPostIncrementRule($helper);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function getExpectedErrors(): array
+	{
+		return [
+			[
+				'Only numeric types are allowed in post-increment, false given.',
+				32,
+			],
+			[
+				'Only numeric types are allowed in post-increment, string given.',
+				33,
+			],
+			[
+				'Only numeric types are allowed in post-increment, null given.',
+				34,
+			],
+			[
+				'Only numeric types are allowed in post-increment, stdClass given.',
+				35,
+			],
+			[
+				'Only numeric types are allowed in post-increment, int|stdClass|string given.',
+				37,
+			],
+		];
+	}
+
+}

--- a/tests/Rules/Operators/OperandInArithmeticPreDecrementRuleTest.php
+++ b/tests/Rules/Operators/OperandInArithmeticPreDecrementRuleTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PHPStan\Rules\Rule;
+
+class OperandInArithmeticPreDecrementRuleTest extends OperandInArithmeticIncrementOrDecrementRuleTest
+{
+
+	protected function createRule(OperatorRuleHelper $helper): Rule
+	{
+		return new OperandInArithmeticPreDecrementRule($helper);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function getExpectedErrors(): array
+	{
+		return [
+			[
+				'Only numeric types are allowed in pre-decrement, false given.',
+				43,
+			],
+			[
+				'Only numeric types are allowed in pre-decrement, string given.',
+				44,
+			],
+			[
+				'Only numeric types are allowed in pre-decrement, null given.',
+				45,
+			],
+			[
+				'Only numeric types are allowed in pre-decrement, stdClass given.',
+				46,
+			],
+			[
+				'Only numeric types are allowed in pre-decrement, int|stdClass|string given.',
+				48,
+			],
+		];
+	}
+
+}

--- a/tests/Rules/Operators/OperandInArithmeticPreIncrementRuleTest.php
+++ b/tests/Rules/Operators/OperandInArithmeticPreIncrementRuleTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PHPStan\Rules\Rule;
+
+class OperandInArithmeticPreIncrementRuleTest extends OperandInArithmeticIncrementOrDecrementRuleTest
+{
+
+	protected function createRule(OperatorRuleHelper $helper): Rule
+	{
+		return new OperandInArithmeticPreIncrementRule($helper);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function getExpectedErrors(): array
+	{
+		return [
+			[
+				'Only numeric types are allowed in pre-increment, false given.',
+				54,
+			],
+			[
+				'Only numeric types are allowed in pre-increment, string given.',
+				55,
+			],
+			[
+				'Only numeric types are allowed in pre-increment, null given.',
+				56,
+			],
+			[
+				'Only numeric types are allowed in pre-increment, stdClass given.',
+				57,
+			],
+			[
+				'Only numeric types are allowed in pre-increment, int|stdClass|string given.',
+				59,
+			],
+		];
+	}
+
+}

--- a/tests/Rules/Operators/data/increment-decrement.php
+++ b/tests/Rules/Operators/data/increment-decrement.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Operators;
+
+use stdClass;
+
+$int = 123;
+$float = 123.456;
+$bool = false;
+$string = 'abc';
+$null = null;
+$object = new stdClass();
+/** @var mixed $mixed */
+$mixed = foo();
+/** @var int|string|stdClass $union */
+$union = bar();
+
+(function () use ($int, $float, $bool, $string, $null, $object, $mixed, $union): void {
+	$int--;
+	$float--;
+	$bool--;
+	$string--;
+	$null--;
+	$object--;
+	$mixed--;
+	$union--;
+})();
+
+(function () use ($int, $float, $bool, $string, $null, $object, $mixed, $union): void {
+	$int++;
+	$float++;
+	$bool++;
+	$string++;
+	$null++;
+	$object++;
+	$mixed++;
+	$union++;
+})();
+
+(function () use ($int, $float, $bool, $string, $null, $object, $mixed, $union): void {
+	--$int;
+	--$float;
+	--$bool;
+	--$string;
+	--$null;
+	--$object;
+	--$mixed;
+	--$union;
+})();
+
+(function () use ($int, $float, $bool, $string, $null, $object, $mixed, $union): void {
+	++$int;
+	++$float;
+	++$bool;
+	++$string;
+	++$null;
+	++$object;
+	++$mixed;
+	++$union;
+})();


### PR DESCRIPTION
Type check for `int`/`float` in:

* `$foo++`
* `$foo--`
* `++$foo`
* `--$foo`

Note that PHP allows wide range of scary and inconsistent magic in these operators which I do **not** want to implement; some examples:

```php
php > $x = false;
php > $x++;
php > var_dump($x);
bool(false)
```
```php
php > $x = 'xx';
php > $x++;
php > var_dump($x);
string(2) "xy"
```
```php
php > $x--;
php > var_dump($x);
string(2) "xy"
```
```php
php > $x = '?';
php > $x++;
php > var_dump($x);
string(1) "?"
```
```php
php > $x = 'x2';
php > $x++;
php > var_dump($x);
string(2) "x3"
php > $x = 'x7';
php > $x++;
php > $x++;
php > $x++;
php > var_dump($x);
string(2) "y0"
```
```php
php > $x = 'zz';
php > $x++;
php > var_dump($x);
string(3) "aaa"
```
```php
php > $x = ';z9';
php > $x++;
php > $x++;
php > $x++;
php > var_dump($x);
string(3) ";a2"
```

![](https://user-images.githubusercontent.com/144181/41549348-d83b99ac-7325-11e8-9f66-42a2f96bdab7.png)
