### PR TITLE
Specify the configuration key for including rules one-by-one

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ includes:
 
 ## Enabling rules one-by-one
 
-If you don't want to start using all the available strict rules at once but only one or two, you can! Just don't include the whole `rules.neon` from this package in your configuration, but look at its contents and copy only the rules you want to your configuration:
+If you don't want to start using all the available strict rules at once but only one or two, you can! Just don't include the whole `rules.neon` from this package in your configuration, but look at its contents and copy only the rules you want to your configuration under the `services` key:
 
 ```
+services:
 	-
 		class: PHPStan\Rules\StrictCalls\StrictFunctionCallsRule
 		tags:


### PR DESCRIPTION
The README file is not specific about including rule one-by-one. It needs to be included under the `services` key, otherwise it does not work at all.