### PR TITLE
Prevent accurate comparison of floating-point numbers

### DIFF
--- a/src/Rules/Operators/OperandsInComparisonRule.php
+++ b/src/Rules/Operators/OperandsInComparisonRule.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Type\FloatType;
+
+class OperandsInComparisonRule implements Rule
+{
+
+	public function getNodeType(): string
+	{
+		return BinaryOp::class;
+	}
+
+	/**
+	 * @param Node $node
+	 * @param Scope $scope
+	 * @return string[]
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!$node instanceof BinaryOp\Equal
+			&& !$node instanceof BinaryOp\Identical
+			&& !$node instanceof BinaryOp\NotEqual
+			&& !$node instanceof BinaryOp\NotIdentical
+			&& !$node instanceof BinaryOp\GreaterOrEqual
+			&& !$node instanceof BinaryOp\SmallerOrEqual
+		) {
+			return [];
+		}
+
+		$rightType = $scope->getType($node->right);
+		$leftType = $scope->getType($node->left);
+
+		if ($rightType instanceof FloatType || $leftType instanceof FloatType) {
+			if ($node instanceof  BinaryOp\Equal || $node instanceof BinaryOp\Identical) {
+				return [
+					'Exact comparison of floating-point numbers is not accurate.' . PHP_EOL
+					. 'You should use `abs($left - $right) < $epsilon`, where $epsilon is maximum allowed deviation.',
+				];
+			}
+
+			if ($node instanceof  BinaryOp\NotEqual || $node instanceof BinaryOp\NotIdentical) {
+				return [
+					'Exact comparison of floating-point numbers is not accurate.' . PHP_EOL
+					. 'You should use `abs($left - $right) >= $epsilon`, where $epsilon is maximum allowed deviation.',
+				];
+			}
+
+			if ($node instanceof BinaryOp\GreaterOrEqual) {
+				return [
+					'Exact comparison of floating-point numbers is not accurate.' . PHP_EOL
+					. 'You should use `$left - $right >= $epsilon`, where $epsilon is maximum allowed deviation.',
+				];
+			}
+
+			return [
+				'Exact comparison of floating-point numbers is not accurate.' . PHP_EOL
+				. 'You should use `$right - $left >= $epsilon`, where $epsilon is maximum allowed deviation.',
+			];
+		}
+
+		return [];
+	}
+
+}

--- a/tests/Rules/Operators/OperandsInComparisonRuleTest.php
+++ b/tests/Rules/Operators/OperandsInComparisonRuleTest.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PHPStan\Rules\Rule;
+
+class OperandsInComparisonRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new OperandsInComparisonRule();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/operators.php'], [
+			[
+				'Exact comparison of floating-point numbers is not accurate.' . PHP_EOL
+				. 'You should use `abs($left - $right) < $epsilon`, where $epsilon is maximum allowed deviation.',
+				113,
+			],
+			[
+				'Exact comparison of floating-point numbers is not accurate.' . PHP_EOL
+				. 'You should use `abs($left - $right) < $epsilon`, where $epsilon is maximum allowed deviation.',
+				114,
+			],
+			[
+				'Exact comparison of floating-point numbers is not accurate.' . PHP_EOL
+				. 'You should use `abs($left - $right) >= $epsilon`, where $epsilon is maximum allowed deviation.',
+				115,
+			],
+			[
+				'Exact comparison of floating-point numbers is not accurate.' . PHP_EOL
+				. 'You should use `abs($left - $right) >= $epsilon`, where $epsilon is maximum allowed deviation.',
+				116,
+			],
+			[
+				'Exact comparison of floating-point numbers is not accurate.' . PHP_EOL
+				. 'You should use `$left - $right >= $epsilon`, where $epsilon is maximum allowed deviation.',
+				117,
+			],
+			[
+				'Exact comparison of floating-point numbers is not accurate.' . PHP_EOL
+				. 'You should use `$right - $left >= $epsilon`, where $epsilon is maximum allowed deviation.',
+				118,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/Operators/data/operators.php
+++ b/tests/Rules/Operators/data/operators.php
@@ -109,3 +109,10 @@ function (array $array, int $int, $mixed) {
 
 	explode($mixed, $mixed) + $int;
 };
+
+$float === 123.2;
+$float == 123.2;
+$float !== 123.2;
+$float != 123.2;
+$float >= 123.2;
+$float <= 123.2;


### PR DESCRIPTION
Prevent situation when comparison return can unexpected result. For example:


    php > $a = 0.15 + 0.15;
    php > $b = 0.1 + 0.2;
    php > $c = 0.3;
    php > var_dump($a === $b);
    bool(false)
    php > var_dump($b == $c);
    bool(false)
    php > var_dump($b <= $c);
    bool(false)
```