### PR TITLE
Add operand in ternary operators rule

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -508,6 +508,16 @@ parameters:
 			path: tests/Rules/Operators/OperandsInArithmeticSubtractionRuleTest.php
 
 		-
+			message: "#^Class PHPStan\\\\Rules\\\\Operators\\\\OperandsInTernaryOperatorRuleTest extends generic class PHPStan\\\\Testing\\\\RuleTestCase but does not specify its types\\: TRule$#"
+			count: 1
+			path: tests/Rules/Operators/OperandsInTernaryOperatorRuleTest.php
+
+		-
+			message: "#^Method PHPStan\\\\Rules\\\\Operators\\\\OperandsInTernaryOperatorRuleTest\\:\\:getRule\\(\\) return type with generic interface PHPStan\\\\Rules\\\\Rule does not specify its types\\: TNodeType$#"
+			count: 1
+			path: tests/Rules/Operators/OperandsInTernaryOperatorRuleTest.php
+
+		-
 			message: "#^Class PHPStan\\\\Rules\\\\StrictCalls\\\\DynamicCallOnStaticMethodsRuleTest extends generic class PHPStan\\\\Testing\\\\RuleTestCase but does not specify its types\\: TRule$#"
 			count: 1
 			path: tests/Rules/StrictCalls/DynamicCallOnStaticMethodsRuleTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -508,16 +508,6 @@ parameters:
 			path: tests/Rules/Operators/OperandsInArithmeticSubtractionRuleTest.php
 
 		-
-			message: "#^Class PHPStan\\\\Rules\\\\Operators\\\\OperandsInTernaryOperatorRuleTest extends generic class PHPStan\\\\Testing\\\\RuleTestCase but does not specify its types\\: TRule$#"
-			count: 1
-			path: tests/Rules/Operators/OperandsInTernaryOperatorRuleTest.php
-
-		-
-			message: "#^Method PHPStan\\\\Rules\\\\Operators\\\\OperandsInTernaryOperatorRuleTest\\:\\:getRule\\(\\) return type with generic interface PHPStan\\\\Rules\\\\Rule does not specify its types\\: TNodeType$#"
-			count: 1
-			path: tests/Rules/Operators/OperandsInTernaryOperatorRuleTest.php
-
-		-
 			message: "#^Class PHPStan\\\\Rules\\\\StrictCalls\\\\DynamicCallOnStaticMethodsRuleTest extends generic class PHPStan\\\\Testing\\\\RuleTestCase but does not specify its types\\: TRule$#"
 			count: 1
 			path: tests/Rules/StrictCalls/DynamicCallOnStaticMethodsRuleTest.php

--- a/rules.neon
+++ b/rules.neon
@@ -41,7 +41,14 @@ rules:
 	- PHPStan\Rules\VariableVariables\VariableStaticPropertyFetchRule
 	- PHPStan\Rules\VariableVariables\VariableVariablesRule
 
+conditionalTags:
+	PHPStan\Rules\Operators\OperandsInTernaryOperatorRule:
+		phpstan.rules.rule: %featureToggles.bleedingEdge%
+
 services:
+	-
+		class: PHPStan\Rules\Operators\OperandsInTernaryOperatorRule
+
 	-
 		class: PHPStan\Rules\BooleansInConditions\BooleanRuleHelper
 

--- a/src/Rules/Operators/OperandsInTernaryOperatorRule.php
+++ b/src/Rules/Operators/OperandsInTernaryOperatorRule.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Ternary;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\ConstantType;
+use PHPStan\Type\VerbosityLevel;
+
+/**
+ * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Expr\Ternary>
+ */
+class OperandsInTernaryOperatorRule implements Rule
+{
+
+	public function getNodeType(): string
+	{
+		return Ternary::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$ifType = $node->if === null ? $scope->getType($node->cond) : $scope->getType($node->if);
+		$elseType = $scope->getType($node->else);
+		if ($ifType instanceof ConstantType && $elseType instanceof ConstantType) {
+			if ($ifType->equals($elseType)) {
+				return [sprintf(
+					'If and else parts of ternary operator are equal (%s).',
+					$ifType->describe(VerbosityLevel::value())
+				)];
+			}
+			if ($ifType instanceof ConstantBooleanType && $elseType instanceof ConstantBooleanType) {
+				return $ifType->getValue()
+					? ['Ternary operator is not needed. Use just condition casted to bool.']
+					: ['Ternary operator is not needed. Use condition with negation operator.'];
+			}
+		}
+
+		return [];
+	}
+
+}

--- a/src/Rules/Operators/OperandsInTernaryOperatorRule.php
+++ b/src/Rules/Operators/OperandsInTernaryOperatorRule.php
@@ -6,7 +6,6 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\Ternary;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
-use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\ConstantType;
 use PHPStan\Type\VerbosityLevel;
 
@@ -31,11 +30,6 @@ class OperandsInTernaryOperatorRule implements Rule
 					'If and else parts of ternary operator are equal (%s).',
 					$ifType->describe(VerbosityLevel::value())
 				)];
-			}
-			if ($ifType instanceof ConstantBooleanType && $elseType instanceof ConstantBooleanType) {
-				return $ifType->getValue()
-					? ['Ternary operator is not needed. Use just condition casted to bool.']
-					: ['Ternary operator is not needed. Use condition with negation operator.'];
 			}
 		}
 

--- a/tests/Rules/Operators/OperandsInTernaryOperatorRuleTest.php
+++ b/tests/Rules/Operators/OperandsInTernaryOperatorRuleTest.php
@@ -4,6 +4,9 @@ namespace PHPStan\Rules\Operators;
 
 use PHPStan\Rules\Rule;
 
+/**
+ * @extends \PHPStan\Testing\RuleTestCase<OperandsInTernaryOperatorRule>
+ */
 class OperandsInTernaryOperatorRuleTest extends \PHPStan\Testing\RuleTestCase
 {
 
@@ -34,14 +37,6 @@ class OperandsInTernaryOperatorRuleTest extends \PHPStan\Testing\RuleTestCase
 			[
 				'If and else parts of ternary operator are equal (array(1 => 1)).',
 				122,
-			],
-			[
-				'Ternary operator is not needed. Use condition with negation operator.',
-				125,
-			],
-			[
-				'Ternary operator is not needed. Use just condition casted to bool.',
-				126,
 			],
 		]);
 	}

--- a/tests/Rules/Operators/OperandsInTernaryOperatorRuleTest.php
+++ b/tests/Rules/Operators/OperandsInTernaryOperatorRuleTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PHPStan\Rules\Rule;
+
+class OperandsInTernaryOperatorRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new OperandsInTernaryOperatorRule();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/operators.php'], [
+			[
+				'If and else parts of ternary operator are equal (true).',
+				113,
+			],
+			[
+				'If and else parts of ternary operator are equal (array()).',
+				118,
+			],
+			[
+				'If and else parts of ternary operator are equal (\'string_val\').',
+				119,
+			],
+			[
+				'If and else parts of ternary operator are equal (array(23, 24)).',
+				121,
+			],
+			[
+				'If and else parts of ternary operator are equal (array(1 => 1)).',
+				122,
+			],
+			[
+				'Ternary operator is not needed. Use condition with negation operator.',
+				125,
+			],
+			[
+				'Ternary operator is not needed. Use just condition casted to bool.',
+				126,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/Operators/data/operators.php
+++ b/tests/Rules/Operators/data/operators.php
@@ -109,3 +109,18 @@ function (array $array, int $int, $mixed) {
 
 	explode($mixed, $mixed) + $int;
 };
+
+foo() ? true : true;
+foo() ? true : null;
+foo() ? $object : true;
+foo() ? $object : false;
+foo() ? $object : null;
+foo() ? [] : [];
+foo() ? 'string_val' : 'string_val';
+foo() ? [23, 24] : [23, 25];
+foo() ? [23, 24] : [23, 24];
+foo() ? [1 => 1] : ['1' => 1];
+foo() ? [1 => 1] : ['asd' => 1];
+$object ?: $object;
+foo() ? false : true;
+foo() ? true : false;


### PR DESCRIPTION
Find unnecessary ternary operators, when if and else part are equal or if and else part could be replaced by condition casted to bool.