### PR TITLE
Fix: Use appropriate sections for Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,13 @@ php:
   - 7.1
   - 7.2
   - 7.3
-before_script:
+
+before_install:
   - composer self-update
+
+install:
   - composer install
+
 script:
   - vendor/bin/phing
   - >


### PR DESCRIPTION
This PR

* [x] uses appropriate sections to run things during the Travis build

💁‍♂️ Also adds a bit of vertical whitespace for enhanced legibility! For reference, see https://docs.travis-ci.com/user/job-lifecycle/#the-job-lifecycle.