### PR TITLE
Fix: No need to update composer twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ php:
   - 7.2
   - 7.3
 before_script:
-  - composer self-update
   - composer install
 script:
   - vendor/bin/phing


### PR DESCRIPTION
This PR

- [x] avoids running `composer self–update` twice on Travis CI
