### PR TITLE
Enhancement: Run 'composer normalize' as part of the build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -5,6 +5,7 @@
 		composer,
 		lint,
 		cs,
+		composer-normalize-check,
 		tests,
 		phpstan
 	"/>
@@ -17,6 +18,31 @@
 				checkreturn="true"
 		>
 			<arg value="install"/>
+		</exec>
+	</target>
+
+	<target name="composer-normalize-check">
+		<exec
+				executable="composer"
+				logoutput="true"
+				passthru="true"
+				checkreturn="true"
+		>
+			<arg value="normalize"/>
+			<arg value="--ansi"/>
+			<arg value="--dry-run"/>
+		</exec>
+	</target>
+
+	<target name="composer-normalize-fix">
+		<exec
+				executable="composer"
+				logoutput="true"
+				passthru="true"
+				checkreturn="true"
+		>
+			<arg value="normalize"/>
+			<arg value="--ansi"/>
 		</exec>
 	</target>
 

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
 		"consistence/coding-standard": "^3.0.1",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
 		"jakub-onderka/php-parallel-lint": "^1.0",
+		"localheinz/composer-normalize": "^1.2.0",
 		"phing/phing": "^2.16.0",
 		"phpstan/phpstan-phpunit": "^0.12",
 		"phpunit/phpunit": "^7.0",


### PR DESCRIPTION
This PR

* [x] requires `localheinz/composer-normalize` and runs `composer normalize` as part of the build

💁‍♂ Follows https://github.com/phpstan/phpstan-strict-rules/pull/71#issuecomment-523625550.