### PR TITLE
Fix false positive on static calls on classes where both static and dynamic calls are possible

### DIFF
--- a/src/Rules/StrictCalls/DynamicCallOnStaticMethodsRule.php
+++ b/src/Rules/StrictCalls/DynamicCallOnStaticMethodsRule.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
+use PHPStan\TrinaryLogic;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\Type;
 use function sprintf;
@@ -52,7 +53,7 @@ class DynamicCallOnStaticMethodsRule implements Rule
 		}
 
 		$methodReflection = $type->getMethod($name, $scope);
-		if ($methodReflection->isStatic()) {
+		if ($methodReflection->isStatic() && $type->hasMethod('__callStatic') === TrinaryLogic::createNo()) {
 			return [sprintf(
 				'Dynamic call to static method %s::%s().',
 				$methodReflection->getDeclaringClass()->getDisplayName(),

--- a/src/Rules/StrictCalls/DynamicCallOnStaticMethodsRule.php
+++ b/src/Rules/StrictCalls/DynamicCallOnStaticMethodsRule.php
@@ -53,7 +53,7 @@ class DynamicCallOnStaticMethodsRule implements Rule
 		}
 
 		$methodReflection = $type->getMethod($name, $scope);
-		if ($methodReflection->isStatic() && $type->hasMethod('__callStatic') === TrinaryLogic::createNo()) {
+		if ($methodReflection->isStatic() && $type->hasMethod('__callStatic') !== TrinaryLogic::createYes()) {
 			return [sprintf(
 				'Dynamic call to static method %s::%s().',
 				$methodReflection->getDeclaringClass()->getDisplayName(),


### PR DESCRIPTION
When a method can be called both dynamically and statically, the method is marked as dynamic and static calls are not allowed as outlined in #140 . This change fixes false positives when methods can be called both static and dynamically.