### PR TITLE
ignore build-cs folder in releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,5 @@ Makefile export-ignore
 phpcs.xml export-ignore
 phpstan.neon export-ignore
 phpunit.xml export-ignore
+
+/build-cs export-ignore


### PR DESCRIPTION
inspired by https://github.com/phpstan/phpstan-phpunit/blob/4cc5c6cc38e56bce7ea47c4091814e516d172dc3/.gitattributes#L6

I am wondering though, that this repo contains a `test/` folder which is not export-ignored, but also is not included in the release?

<img width="476" alt="grafik" src="https://user-images.githubusercontent.com/120441/225752286-41536875-7511-4609-aeef-24e82999501b.png">
