### PR TITLE
Add default value to operator rules

### DIFF
--- a/src/Rules/Operators/OperandsInArithmeticAdditionRule.php
+++ b/src/Rules/Operators/OperandsInArithmeticAdditionRule.php
@@ -21,7 +21,7 @@ class OperandsInArithmeticAdditionRule implements Rule
 	/** @var bool */
 	private $bleedingEdge;
 
-	public function __construct(OperatorRuleHelper $helper, bool $bleedingEdge)
+	public function __construct(OperatorRuleHelper $helper, bool $bleedingEdge = false)
 	{
 		$this->helper = $helper;
 		$this->bleedingEdge = $bleedingEdge;

--- a/src/Rules/Operators/OperandsInArithmeticDivisionRule.php
+++ b/src/Rules/Operators/OperandsInArithmeticDivisionRule.php
@@ -20,7 +20,7 @@ class OperandsInArithmeticDivisionRule implements Rule
 	/** @var bool */
 	private $bleedingEdge;
 
-	public function __construct(OperatorRuleHelper $helper, bool $bleedingEdge)
+	public function __construct(OperatorRuleHelper $helper, bool $bleedingEdge = false)
 	{
 		$this->helper = $helper;
 		$this->bleedingEdge = $bleedingEdge;

--- a/src/Rules/Operators/OperandsInArithmeticExponentiationRule.php
+++ b/src/Rules/Operators/OperandsInArithmeticExponentiationRule.php
@@ -20,7 +20,7 @@ class OperandsInArithmeticExponentiationRule implements Rule
 	/** @var bool */
 	private $bleedingEdge;
 
-	public function __construct(OperatorRuleHelper $helper, bool $bleedingEdge)
+	public function __construct(OperatorRuleHelper $helper, bool $bleedingEdge = false)
 	{
 		$this->helper = $helper;
 		$this->bleedingEdge = $bleedingEdge;

--- a/src/Rules/Operators/OperandsInArithmeticModuloRule.php
+++ b/src/Rules/Operators/OperandsInArithmeticModuloRule.php
@@ -20,7 +20,7 @@ class OperandsInArithmeticModuloRule implements Rule
 	/** @var bool */
 	private $bleedingEdge;
 
-	public function __construct(OperatorRuleHelper $helper, bool $bleedingEdge)
+	public function __construct(OperatorRuleHelper $helper, bool $bleedingEdge = false)
 	{
 		$this->helper = $helper;
 		$this->bleedingEdge = $bleedingEdge;

--- a/src/Rules/Operators/OperandsInArithmeticMultiplicationRule.php
+++ b/src/Rules/Operators/OperandsInArithmeticMultiplicationRule.php
@@ -20,7 +20,7 @@ class OperandsInArithmeticMultiplicationRule implements Rule
 	/** @var bool */
 	private $bleedingEdge;
 
-	public function __construct(OperatorRuleHelper $helper, bool $bleedingEdge)
+	public function __construct(OperatorRuleHelper $helper, bool $bleedingEdge = false)
 	{
 		$this->helper = $helper;
 		$this->bleedingEdge = $bleedingEdge;

--- a/src/Rules/Operators/OperandsInArithmeticSubtractionRule.php
+++ b/src/Rules/Operators/OperandsInArithmeticSubtractionRule.php
@@ -20,7 +20,7 @@ class OperandsInArithmeticSubtractionRule implements Rule
 	/** @var bool */
 	private $bleedingEdge;
 
-	public function __construct(OperatorRuleHelper $helper, bool $bleedingEdge)
+	public function __construct(OperatorRuleHelper $helper, bool $bleedingEdge = false)
 	{
 		$this->helper = $helper;
 		$this->bleedingEdge = $bleedingEdge;


### PR DESCRIPTION
This should fix this error that appear after updating the latest phpstan: 

```
Service 'rules.164' (type of PHPStan\Rules\Operators\OperandsInArithmeticAdditionRule): Parameter $bleedingEdge in OperandsInArithmeticAdditionRule::__construct() has no class type or default value, so its value must be specified.
```
