### PR TITLE
Allow 'make' to work first time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@
 check: lint cs tests phpstan
 
 .PHONY: tests
-tests:
+tests: vendor
 	php vendor/bin/phpunit
 
 .PHONY: lint
-lint:
+lint: vendor
 	php vendor/bin/parallel-lint --colors \
 		src tests
 
@@ -17,13 +17,19 @@ cs-install:
 	composer install --working-dir build-cs
 
 .PHONY: cs
-cs:
+cs: cs-install
 	php build-cs/vendor/bin/phpcs --standard=build-cs/phpcs.xml src tests
 
 .PHONY: cs-fix
-cs-fix:
+cs-fix: cs-install
 	php build-cs/vendor/bin/phpcbf --standard=build-cs/phpcs.xml src tests
 
 .PHONY: phpstan
-phpstan:
+phpstan: vendor
 	php vendor/bin/phpstan analyse -l 8 -c phpstan.neon src tests
+
+vendor: composer.json composer.lock
+	composer --no-interaction install
+
+composer.lock:
+	test -f composer.lock || composer --no-interaction update


### PR DESCRIPTION
I am looking into a suspected bug, so I cloned this repository to review the code. I wanted to check that the tests worked locally on the main branch before trying to make any changes. However, when I ran `make`, I got errors. The changes in this pull request allow `make` to work first time.