### PR TITLE
Add rule to disallow error control operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 * Check LSP even for static methods
 * Require calling parent constructor
 * Disallow usage of backtick operator (`` $ls = `ls -la` ``)
+* Disallow usage of error control operators(`@callSomeFunc()`)
 * Closure should use `$this` directly instead of using `$this` variable indirectly
 
 Additional rules are coming in subsequent releases!

--- a/rules.neon
+++ b/rules.neon
@@ -70,6 +70,8 @@ conditionalTags:
 		phpstan.rules.rule: %strictRules.disallowedConstructs%
 	PHPStan\Rules\DisallowedConstructs\DisallowedEmptyRule:
 		phpstan.rules.rule: %strictRules.disallowedConstructs%
+	PHPStan\Rules\DisallowedConstructs\DisallowedErrorControlRule:
+		phpstan.rules.rule: %strictRules.disallowedConstructs%
 	PHPStan\Rules\DisallowedConstructs\DisallowedImplicitArrayCreationRule:
 		phpstan.rules.rule: %strictRules.disallowedConstructs%
 	PHPStan\Rules\DisallowedConstructs\DisallowedShortTernaryRule:
@@ -175,6 +177,9 @@ services:
 
 	-
 		class: PHPStan\Rules\DisallowedConstructs\DisallowedEmptyRule
+
+	-
+		class: PHPStan\Rules\DisallowedConstructs\DisallowedErrorControlRule
 
 	-
 		class: PHPStan\Rules\DisallowedConstructs\DisallowedImplicitArrayCreationRule

--- a/src/Rules/DisallowedConstructs/DisallowedErrorControlRule.php
+++ b/src/Rules/DisallowedConstructs/DisallowedErrorControlRule.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\DisallowedConstructs;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ErrorSuppress;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<ErrorSuppress>
+ */
+class DisallowedErrorControlRule implements Rule
+{
+
+	public function getNodeType(): string
+	{
+		return ErrorSuppress::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		return [
+			RuleErrorBuilder::message('Error control operator (`@`) is not allowed.')
+				->identifier('errorControl.notAllowed')
+				->build(),
+		];
+	}
+
+}

--- a/tests/Rules/DisallowedConstructs/DisallowedErrorControlRuleTest.php
+++ b/tests/Rules/DisallowedConstructs/DisallowedErrorControlRuleTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\DisallowedConstructs;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<DisallowedErrorControlRule>
+ */
+class DisallowedErrorControlRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new DisallowedErrorControlRule();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/error-control.php'], [
+			[
+				'Error control operator (`@`) is not allowed.',
+				3,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/DisallowedConstructs/data/error-control.php
+++ b/tests/Rules/DisallowedConstructs/data/error-control.php
@@ -1,0 +1,3 @@
+<?php
+
+@file_get_contents('non-exists-file');


### PR DESCRIPTION
## Overview
This Pull Request introduces a new static analysis rule that prohibits the use of PHP's error control operator (@).

## Specification
This rule will flag lines of code that use the error control operator @, issuing a warning or error for that line.

## Background and Motivation
The error control operator is frequently misused, often exceeding its appropriate scope, to ignore or suppress errors. This misuse is well-known for posing risks that can degrade the quality of application code and complicate debugging.

By adding this new rule, we believe the following benefits can be achieved:

1. Encourage the practice of proper error handling and clearer coding.
2. Prevent the decrease in debuggability due to the use of the error control operator.

I believe that this rule will help PHPStan users to adopt a more strict coding style, thereby assisting in the development of more reliable software.