### PR TITLE
Allow to not call a deprecated parent constructor

### DIFF
--- a/src/Rules/Classes/RequireParentConstructCallRule.php
+++ b/src/Rules/Classes/RequireParentConstructCallRule.php
@@ -113,6 +113,7 @@ class RequireParentConstructCallRule implements Rule
 					&& $constructor->getDeclaringClass()->getName() === $classReflection->getParentClass()->getName()
 					&& !$constructor->isAbstract()
 					&& !$constructor->isPrivate()
+					&& !$constructor->isDeprecated()
 				) || (
 					$constructorWithClassName !== null
 					&& $constructorWithClassName->getDeclaringClass()->getName() === $classReflection->getParentClass()->getName()

--- a/tests/Rules/Classes/data/call-to-parent-constructor.php
+++ b/tests/Rules/Classes/data/call-to-parent-constructor.php
@@ -181,3 +181,22 @@ class ExtendsPrivateConstructor extends PrivateConstructor
 	}
 
 }
+
+class DeprecatedConstructor
+{
+	/** @deprecated */
+	public function __construct()
+	{
+
+	}
+
+}
+
+class ExtendsDeprecatedConstructor extends DeprecatedConstructor
+{
+	public function __construct()
+	{
+		// should not call deprecated parent
+	}
+
+}


### PR DESCRIPTION
Fix https://github.com/phpstan/phpstan-strict-rules/issues/257