### PR TITLE
Check for boolean in while conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [PHPStan](https://phpstan.org/) focuses on finding bugs in your code. But in PHP there's a lot of leeway in how stuff can be written. This repository contains additional rules that revolve around strictly and strongly typed code with no loose casting for those who want additional safety in extremely defensive programming:
 
 * Require booleans in `if`, `elseif`, ternary operator, after `!`, and on both sides of `&&` and `||`.
+* Require booleans in `while` and `do while` loop conditions.
 * Require numeric operands or arrays in `+` and numeric operands in `-`/`*`/`/`/`**`/`%`.
 * Require numeric operand in `$var++`, `$var--`, `++$var`and `--$var`.
 * These functions contain a `$strict` parameter for better type safety, it must be set to `true`:
@@ -64,6 +65,7 @@ parameters:
 	strictRules:
 		disallowedLooseComparison: false
 		booleansInConditions: false
+		booleansInLoopConditions: false
 		uselessCast: false
 		requireParentConstructorCall: false
 		disallowedBacktick: false

--- a/rules.neon
+++ b/rules.neon
@@ -64,11 +64,15 @@ conditionalTags:
 		phpstan.rules.rule: %strictRules.booleansInConditions%
 	PHPStan\Rules\BooleansInConditions\BooleanInBooleanOrRule:
 		phpstan.rules.rule: %strictRules.booleansInConditions%
+	PHPStan\Rules\BooleansInConditions\BooleanInDoWhileConditionRule:
+		phpstan.rules.rule: %strictRules.booleansInConditions%
 	PHPStan\Rules\BooleansInConditions\BooleanInElseIfConditionRule:
 		phpstan.rules.rule: %strictRules.booleansInConditions%
 	PHPStan\Rules\BooleansInConditions\BooleanInIfConditionRule:
 		phpstan.rules.rule: %strictRules.booleansInConditions%
 	PHPStan\Rules\BooleansInConditions\BooleanInTernaryOperatorRule:
+		phpstan.rules.rule: %strictRules.booleansInConditions%
+	PHPStan\Rules\BooleansInConditions\BooleanInWhileConditionRule:
 		phpstan.rules.rule: %strictRules.booleansInConditions%
 	PHPStan\Rules\Cast\UselessCastRule:
 		phpstan.rules.rule: %strictRules.uselessCast%
@@ -164,6 +168,9 @@ services:
 		class: PHPStan\Rules\BooleansInConditions\BooleanInBooleanOrRule
 
 	-
+		class: PHPStan\Rules\BooleansInConditions\BooleanInDoWhileConditionRule
+
+	-
 		class: PHPStan\Rules\BooleansInConditions\BooleanInElseIfConditionRule
 
 	-
@@ -171,6 +178,9 @@ services:
 
 	-
 		class: PHPStan\Rules\BooleansInConditions\BooleanInTernaryOperatorRule
+
+	-
+		class: PHPStan\Rules\BooleansInConditions\BooleanInWhileConditionRule
 
 	-
 		class: PHPStan\Rules\Cast\UselessCastRule

--- a/rules.neon
+++ b/rules.neon
@@ -15,6 +15,7 @@ parameters:
 		allRules: true
 		disallowedLooseComparison: %strictRules.allRules%
 		booleansInConditions: %strictRules.allRules%
+		booleansInLoopConditions: [%strictRules.allRules%, %featureToggles.bleedingEdge%]
 		uselessCast: %strictRules.allRules%
 		requireParentConstructorCall: %strictRules.allRules%
 		disallowedBacktick: %strictRules.allRules%
@@ -37,6 +38,7 @@ parametersSchema:
 		allRules: anyOf(bool(), arrayOf(bool())),
 		disallowedLooseComparison: anyOf(bool(), arrayOf(bool())),
 		booleansInConditions: anyOf(bool(), arrayOf(bool()))
+		booleansInLoopConditions: anyOf(bool(), arrayOf(bool()))
 		uselessCast: anyOf(bool(), arrayOf(bool()))
 		requireParentConstructorCall: anyOf(bool(), arrayOf(bool()))
 		disallowedBacktick: anyOf(bool(), arrayOf(bool()))
@@ -65,7 +67,7 @@ conditionalTags:
 	PHPStan\Rules\BooleansInConditions\BooleanInBooleanOrRule:
 		phpstan.rules.rule: %strictRules.booleansInConditions%
 	PHPStan\Rules\BooleansInConditions\BooleanInDoWhileConditionRule:
-		phpstan.rules.rule: %strictRules.booleansInConditions%
+		phpstan.rules.rule: %strictRules.booleansInLoopConditions%
 	PHPStan\Rules\BooleansInConditions\BooleanInElseIfConditionRule:
 		phpstan.rules.rule: %strictRules.booleansInConditions%
 	PHPStan\Rules\BooleansInConditions\BooleanInIfConditionRule:
@@ -73,7 +75,7 @@ conditionalTags:
 	PHPStan\Rules\BooleansInConditions\BooleanInTernaryOperatorRule:
 		phpstan.rules.rule: %strictRules.booleansInConditions%
 	PHPStan\Rules\BooleansInConditions\BooleanInWhileConditionRule:
-		phpstan.rules.rule: %strictRules.booleansInConditions%
+		phpstan.rules.rule: %strictRules.booleansInLoopConditions%
 	PHPStan\Rules\Cast\UselessCastRule:
 		phpstan.rules.rule: %strictRules.uselessCast%
 	PHPStan\Rules\Classes\RequireParentConstructCallRule:

--- a/src/Rules/BooleansInConditions/BooleanInDoWhileConditionRule.php
+++ b/src/Rules/BooleansInConditions/BooleanInDoWhileConditionRule.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\BooleansInConditions;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Do_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\VerbosityLevel;
+use function sprintf;
+
+/**
+ * @implements Rule<Do_>
+ */
+class BooleanInDoWhileConditionRule implements Rule
+{
+
+	private BooleanRuleHelper $helper;
+
+	public function __construct(BooleanRuleHelper $helper)
+	{
+		$this->helper = $helper;
+	}
+
+	public function getNodeType(): string
+	{
+		return Do_::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if ($this->helper->passesAsBoolean($scope, $node->cond)) {
+			return [];
+		}
+
+		$conditionExpressionType = $scope->getType($node->cond);
+
+		return [
+			RuleErrorBuilder::message(sprintf(
+				'Only booleans are allowed in a do-while condition, %s given.',
+				$conditionExpressionType->describe(VerbosityLevel::typeOnly()),
+			))->identifier('doWhile.condNotBoolean')->build(),
+		];
+	}
+
+}

--- a/src/Rules/BooleansInConditions/BooleanInDoWhileConditionRule.php
+++ b/src/Rules/BooleansInConditions/BooleanInDoWhileConditionRule.php
@@ -3,7 +3,6 @@
 namespace PHPStan\Rules\BooleansInConditions;
 
 use PhpParser\Node;
-use PhpParser\Node\Stmt\Do_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -11,7 +10,7 @@ use PHPStan\Type\VerbosityLevel;
 use function sprintf;
 
 /**
- * @implements Rule<Do_>
+ * @implements Rule<Node\Stmt\Do_>
  */
 class BooleanInDoWhileConditionRule implements Rule
 {
@@ -25,7 +24,7 @@ class BooleanInDoWhileConditionRule implements Rule
 
 	public function getNodeType(): string
 	{
-		return Do_::class;
+		return Node\Stmt\Do_::class;
 	}
 
 	public function processNode(Node $node, Scope $scope): array

--- a/src/Rules/BooleansInConditions/BooleanInWhileConditionRule.php
+++ b/src/Rules/BooleansInConditions/BooleanInWhileConditionRule.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\BooleansInConditions;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\While_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\VerbosityLevel;
+use function sprintf;
+
+/**
+ * @implements Rule<While_>
+ */
+class BooleanInWhileConditionRule implements Rule
+{
+
+	private BooleanRuleHelper $helper;
+
+	public function __construct(BooleanRuleHelper $helper)
+	{
+		$this->helper = $helper;
+	}
+
+	public function getNodeType(): string
+	{
+		return While_::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if ($this->helper->passesAsBoolean($scope, $node->cond)) {
+			return [];
+		}
+
+		$conditionExpressionType = $scope->getType($node->cond);
+
+		return [
+			RuleErrorBuilder::message(sprintf(
+				'Only booleans are allowed in a while condition, %s given.',
+				$conditionExpressionType->describe(VerbosityLevel::typeOnly()),
+			))->identifier('while.condNotBoolean')->build(),
+		];
+	}
+
+}

--- a/src/Rules/BooleansInConditions/BooleanInWhileConditionRule.php
+++ b/src/Rules/BooleansInConditions/BooleanInWhileConditionRule.php
@@ -3,7 +3,6 @@
 namespace PHPStan\Rules\BooleansInConditions;
 
 use PhpParser\Node;
-use PhpParser\Node\Stmt\While_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -11,7 +10,7 @@ use PHPStan\Type\VerbosityLevel;
 use function sprintf;
 
 /**
- * @implements Rule<While_>
+ * @implements Rule<Node\Stmt\While_>
  */
 class BooleanInWhileConditionRule implements Rule
 {
@@ -25,7 +24,7 @@ class BooleanInWhileConditionRule implements Rule
 
 	public function getNodeType(): string
 	{
-		return While_::class;
+		return Node\Stmt\While_::class;
 	}
 
 	public function processNode(Node $node, Scope $scope): array

--- a/tests/Rules/BooleansInConditions/BooleanInDoWhileConditionRuleTest.php
+++ b/tests/Rules/BooleansInConditions/BooleanInDoWhileConditionRuleTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\BooleansInConditions;
+
+use PHPStan\Rules\BooleansInConditions\BooleanInDoWhileConditionRule;
+use PHPStan\Rules\BooleansInConditions\BooleanRuleHelper;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleLevelHelper;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<BooleanInDoWhileConditionRule>
+ */
+class BooleanInDoWhileConditionRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new BooleanInDoWhileConditionRule(
+			new BooleanRuleHelper(
+				self::getContainer()->getByType(RuleLevelHelper::class),
+			),
+		);
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/conditions.php'], [
+			[
+				'Only booleans are allowed in a do-while condition, string given.',
+				60,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/BooleansInConditions/BooleanInDoWhileConditionRuleTest.php
+++ b/tests/Rules/BooleansInConditions/BooleanInDoWhileConditionRuleTest.php
@@ -2,8 +2,6 @@
 
 namespace PHPStan\Rules\BooleansInConditions;
 
-use PHPStan\Rules\BooleansInConditions\BooleanInDoWhileConditionRule;
-use PHPStan\Rules\BooleansInConditions\BooleanRuleHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;

--- a/tests/Rules/BooleansInConditions/BooleanInWhileConditionRuleTest.php
+++ b/tests/Rules/BooleansInConditions/BooleanInWhileConditionRuleTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\BooleansInConditions;
+
+use PHPStan\Rules\BooleansInConditions\BooleanInWhileConditionRule;
+use PHPStan\Rules\BooleansInConditions\BooleanRuleHelper;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleLevelHelper;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<BooleanInWhileConditionRule>
+ */
+class BooleanInWhileConditionRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new BooleanInWhileConditionRule(
+			new BooleanRuleHelper(
+				self::getContainer()->getByType(RuleLevelHelper::class),
+			),
+		);
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/conditions.php'], [
+			[
+				'Only booleans are allowed in a while condition, string given.',
+				55,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/BooleansInConditions/BooleanInWhileConditionRuleTest.php
+++ b/tests/Rules/BooleansInConditions/BooleanInWhileConditionRuleTest.php
@@ -2,8 +2,6 @@
 
 namespace PHPStan\Rules\BooleansInConditions;
 
-use PHPStan\Rules\BooleansInConditions\BooleanInWhileConditionRule;
-use PHPStan\Rules\BooleansInConditions\BooleanRuleHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;

--- a/tests/Rules/BooleansInConditions/data/conditions.php
+++ b/tests/Rules/BooleansInConditions/data/conditions.php
@@ -48,3 +48,13 @@ $bool and $explicitMixed;
 $explicitMixed and $bool;
 $bool or $explicitMixed;
 $explicitMixed or $bool;
+
+$someBool = true;
+$someString = 'string';
+while ($someBool) { $someBool = !$someBool; }
+while ($someString) { $someString = ''; }
+
+$someBool = true;
+$someString = 'string';
+do { $someBool = !$someBool; } while ($someBool);
+do { $someString = ''; } while ($someString);


### PR DESCRIPTION
Might be enough to close https://github.com/phpstan/phpstan-strict-rules/issues/259

I tried to implement the same thing for `For_`.

But the issue I encounter in 
```
for ($i = 0; $i; $i++) {}
```
is that `$i` is considered as a MixedType, which is non explicit, so `BooleanHelper::passesAsBoolean` always return true.

So i'm unsure the rule is doable for `for` loops.