### PR TITLE
Add numeric check on unary plus and unary minus

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 |:---------------------------------------|:--------------------------------------------------------------------------------------------------------|
 | `booleansInConditions`                 | Require booleans in `if`, `elseif`, ternary operator, after `!`, and on both sides of `&&` and `\|\|`.  |
 | `booleansInLoopConditions`             | Require booleans in `while` and `do while` loop conditions.                                             |
-| `numericOperandsInArithmeticOperators` | Require numeric operands or arrays in `+` and numeric operands in `-`/`*`/`/`/`**`/`%`.                 |
+| `numericOperandsInArithmeticOperators` | Require numeric operand in `+$var`, `-$var`, `$var++`, `$var--`, `++$var` and `--$var`. |
 | `numericOperandsInArithmeticOperators` | Require numeric operand in `$var++`, `$var--`, `++$var`and `--$var`.                                    |
 | `strictFunctionCalls`                  | These functions contain a `$strict` parameter for better type safety, it must be set to `true`:<br>* `in_array` (3rd parameter)<br>* `array_search` (3rd parameter)<br>* `array_keys` (3rd parameter; only if the 2nd parameter `$search_value` is provided)<br>* `base64_decode` (2nd parameter). |
 | `overwriteVariablesWithLoop`           | Variables assigned in `while` loop condition and `for` loop initial assignment cannot be used after the loop.  |

--- a/rules.neon
+++ b/rules.neon
@@ -106,6 +106,10 @@ conditionalTags:
 		phpstan.rules.rule: %strictRules.numericOperandsInArithmeticOperators%
 	PHPStan\Rules\Operators\OperandInArithmeticPreIncrementRule:
 		phpstan.rules.rule: %strictRules.numericOperandsInArithmeticOperators%
+	PHPStan\Rules\Operators\OperandInArithmeticUnaryMinusRule:
+		phpstan.rules.rule: [%strictRules.numericOperandsInArithmeticOperators%, %featureToggles.bleedingEdge%]
+	PHPStan\Rules\Operators\OperandInArithmeticUnaryPlusRule:
+		phpstan.rules.rule: [%strictRules.numericOperandsInArithmeticOperators%, %featureToggles.bleedingEdge%]
 	PHPStan\Rules\Operators\OperandsInArithmeticAdditionRule:
 		phpstan.rules.rule: %strictRules.numericOperandsInArithmeticOperators%
 	PHPStan\Rules\Operators\OperandsInArithmeticDivisionRule:
@@ -241,6 +245,12 @@ services:
 
 	-
 		class: PHPStan\Rules\Operators\OperandInArithmeticPreIncrementRule
+
+	-
+		class: PHPStan\Rules\Operators\OperandInArithmeticUnaryMinusRule
+
+	-
+		class: PHPStan\Rules\Operators\OperandInArithmeticUnaryPlusRule
 
 	-
 		class: PHPStan\Rules\Operators\OperandsInArithmeticAdditionRule

--- a/src/Rules/Operators/OperandInArithmeticUnaryMinusRule.php
+++ b/src/Rules/Operators/OperandInArithmeticUnaryMinusRule.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\UnaryMinus;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\VerbosityLevel;
+use function sprintf;
+
+/**
+ * @phpstan-implements Rule<UnaryMinus>
+ */
+class OperandInArithmeticUnaryMinusRule implements Rule
+{
+
+	private OperatorRuleHelper $helper;
+
+	public function __construct(OperatorRuleHelper $helper)
+	{
+		$this->helper = $helper;
+	}
+
+	public function getNodeType(): string
+	{
+		return UnaryMinus::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$messages = [];
+
+		if (!$this->helper->isValidForArithmeticOperation($scope, $node->expr)) {
+			$varType = $scope->getType($node->expr);
+
+			$messages[] = RuleErrorBuilder::message(sprintf(
+				'Only numeric types are allowed in unary -, %s given.',
+				$varType->describe(VerbosityLevel::typeOnly()),
+			))->identifier('unaryMinus.nonNumeric')->build();
+		}
+
+		return $messages;
+	}
+
+}

--- a/src/Rules/Operators/OperandInArithmeticUnaryPlusRule.php
+++ b/src/Rules/Operators/OperandInArithmeticUnaryPlusRule.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\UnaryPlus;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\VerbosityLevel;
+use function sprintf;
+
+/**
+ * @phpstan-implements Rule<UnaryPlus>
+ */
+class OperandInArithmeticUnaryPlusRule implements Rule
+{
+
+	private OperatorRuleHelper $helper;
+
+	public function __construct(OperatorRuleHelper $helper)
+	{
+		$this->helper = $helper;
+	}
+
+	public function getNodeType(): string
+	{
+		return UnaryPlus::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$messages = [];
+
+		if (!$this->helper->isValidForArithmeticOperation($scope, $node->expr)) {
+			$varType = $scope->getType($node->expr);
+
+			$messages[] = RuleErrorBuilder::message(sprintf(
+				'Only numeric types are allowed in unary +, %s given.',
+				$varType->describe(VerbosityLevel::typeOnly()),
+			))->identifier('unaryPlus.nonNumeric')->build();
+		}
+
+		return $messages;
+	}
+
+}

--- a/tests/Rules/Operators/OperandInArithmeticUnaryMinusRuleTest.php
+++ b/tests/Rules/Operators/OperandInArithmeticUnaryMinusRuleTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleLevelHelper;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<OperandInArithmeticUnaryMinusRule>
+ */
+class OperandInArithmeticUnaryMinusRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new OperandInArithmeticUnaryMinusRule(
+			new OperatorRuleHelper(
+				self::getContainer()->getByType(RuleLevelHelper::class),
+			),
+		);
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/operators.php'], [
+			[
+				'Only numeric types are allowed in unary -, null given.',
+				233,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/Operators/OperandInArithmeticUnaryPlusRuleTest.php
+++ b/tests/Rules/Operators/OperandInArithmeticUnaryPlusRuleTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Operators;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleLevelHelper;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<OperandInArithmeticUnaryPlusRule>
+ */
+class OperandInArithmeticUnaryPlusRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new OperandInArithmeticUnaryPlusRule(
+			new OperatorRuleHelper(
+				self::getContainer()->getByType(RuleLevelHelper::class),
+			),
+		);
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/operators.php'], [
+			[
+				'Only numeric types are allowed in unary +, null given.',
+				225,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/Operators/data/operators.php
+++ b/tests/Rules/Operators/data/operators.php
@@ -215,3 +215,19 @@ function (array $array, int $int, $mixed) {
 /** @var numeric-string $numericString */
 $numericString = doFoo();
 $numericString += 1;
+
++$int;
++$float;
++$intOrFloat;
++$string;
++$array;
++$object;
++$null;
+
+-$int;
+-$float;
+-$intOrFloat;
+-$string;
+-$array;
+-$object;
+-$null;


### PR DESCRIPTION
The operation `$a + $b` and `$a - $b` were checked but it was mising for the unary usage of these operators `+$a` or `-$a`.

Then, I plan to add such check for bitwise operators:
- `&` (AND)
- `|` (OR)
- `<<` (Left shift)
- `>>` (Right shift)
- `^` (XOR)

I assume it should be behind a new config option `numericOperandsInBitwiseOperators` @ondrejmirtes ?