### PR TITLE
UselessCastRule: do cheaper check first

### DIFF
--- a/src/Rules/Cast/UselessCastRule.php
+++ b/src/Rules/Cast/UselessCastRule.php
@@ -55,12 +55,12 @@ class UselessCastRule implements Rule
 					return $ruleErrorBuilder;
 				}
 
-				$expressionTypeWithoutPhpDoc = $scope->getNativeType($node->expr);
-				if ($castType->isSuperTypeOf($expressionTypeWithoutPhpDoc)->yes()) {
+				if (!$this->treatPhpDocTypesAsCertainTip) {
 					return $ruleErrorBuilder;
 				}
 
-				if (!$this->treatPhpDocTypesAsCertainTip) {
+				$expressionTypeWithoutPhpDoc = $scope->getNativeType($node->expr);
+				if ($castType->isSuperTypeOf($expressionTypeWithoutPhpDoc)->yes()) {
 					return $ruleErrorBuilder;
 				}
 


### PR DESCRIPTION
just switching the order of early return conditions, so that simple bool comparisons are done first