### PR TITLE
Add VariableFunctionCallRule

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -130,6 +130,8 @@ conditionalTags:
 		phpstan.rules.rule: %strictRules.strictFunctionCalls%
 	PHPStan\Rules\SwitchConditions\MatchingTypeInSwitchCaseConditionRule:
 		phpstan.rules.rule: %strictRules.switchConditionsMatchingType%
+	PHPStan\Rules\VariableVariables\VariableFunctionCallRule:
+		phpstan.rules.rule: %strictRules.noVariableVariables%
 	PHPStan\Rules\VariableVariables\VariableMethodCallRule:
 		phpstan.rules.rule: %strictRules.noVariableVariables%
 	PHPStan\Rules\VariableVariables\VariableMethodCallableRule:
@@ -281,6 +283,9 @@ services:
 
 	-
 		class: PHPStan\Rules\SwitchConditions\MatchingTypeInSwitchCaseConditionRule
+
+	-
+		class: PHPStan\Rules\VariableVariables\VariableFunctionCallRule
 
 	-
 		class: PHPStan\Rules\VariableVariables\VariableMethodCallRule

--- a/src/Rules/VariableVariables/VariableFunctionCallRule.php
+++ b/src/Rules/VariableVariables/VariableFunctionCallRule.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\VariableVariables;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<FuncCall>
+ */
+class VariableFunctionCallRule implements Rule
+{
+
+	public function getNodeType(): string
+	{
+		return FuncCall::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!$node->name instanceof Node\Expr) {
+			return [];
+		}
+
+		$type = $scope->getType($node->name);
+		if (!$type->isString()->yes() && !$type->isArray()->yes()) {
+			return [];
+		}
+
+		return [
+			RuleErrorBuilder::message('Variable function call.')->identifier('function.dynamicName')->build(),
+		];
+	}
+
+}

--- a/tests/Rules/VariableVariables/VariableFunctionCallRuleTest.php
+++ b/tests/Rules/VariableVariables/VariableFunctionCallRuleTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\VariableVariables;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<VariableFunctionCallRule>
+ */
+class VariableFunctionCallRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new VariableFunctionCallRule();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/functions.php'], [
+			[
+				'Variable function call.',
+				6,
+			],
+			[
+				'Variable function call.',
+				14,
+			],
+			[
+				'Variable function call.',
+				16,
+			],
+			[
+				'Variable function call.',
+				18,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/VariableVariables/data/functions.php
+++ b/tests/Rules/VariableVariables/data/functions.php
@@ -1,0 +1,19 @@
+<?php // lint >= 8.1
+
+function (callable $a, string $b) {
+	time();
+	$a();
+	$b();
+	$c = function () {};
+	$c();
+	$d = fn ($a) => $a;
+	$d();
+	$e = time(...);
+	$e();
+	$f = 'time';
+	$f();
+	$g = ['PDO', 'connect'];
+	$g();
+	$h = ['PDO', $b];
+	$h();
+};


### PR DESCRIPTION
This disallows calling random strings and arrays. Calling callables is still allowed.