### PR TITLE
enable checkStrictPrintfPlaceholderTypes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	],
 	"require": {
 		"php": "^7.4 || ^8.0",
-		"phpstan/phpstan": "^2.0.4"
+		"phpstan/phpstan": "^2.1.29"
 	},
 	"require-dev": {
 		"php-parallel-lint/php-parallel-lint": "^1.2",

--- a/rules.neon
+++ b/rules.neon
@@ -11,6 +11,7 @@ parameters:
 	reportStaticMethodSignatures: true
 	reportMaybesInPropertyPhpDocTypes: true
 	reportWrongPhpDocTypeInVarTag: true
+	checkStrictPrintfPlaceholderTypes: true
 	strictRules:
 		allRules: true
 		disallowedLooseComparison: %strictRules.allRules%


### PR DESCRIPTION
Follow up to https://github.com/phpstan/phpstan-src/pull/4349#issuecomment-3313729927

Note that it won't do anything without Bleeding Edge, because the rule itself isn't enabled.