### PR TITLE
POC - Allow short ternary for false

### DIFF
--- a/src/Rules/DisallowedConstructs/DisallowedShortTernaryRule.php
+++ b/src/Rules/DisallowedConstructs/DisallowedShortTernaryRule.php
@@ -7,6 +7,10 @@ use PhpParser\Node\Expr\Ternary;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\StaticTypeFactory;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
 
 /**
  * @implements Rule<Ternary>
@@ -25,11 +29,29 @@ class DisallowedShortTernaryRule implements Rule
 			return [];
 		}
 
+		if ($scope->getType($node->cond)->isSuperTypeOf($this->getNonBooleanFalseyType())->no()) {
+			return [];
+		}
+
 		return [
 			RuleErrorBuilder::message('Short ternary operator is not allowed. Use null coalesce operator if applicable or consider using long ternary.')
 				->identifier('ternary.shortNotAllowed')
 				->build(),
 		];
+	}
+
+	private function getNonBooleanFalseyType(): Type
+	{
+		static $falseyWithoutFalse;
+
+		if ($falseyWithoutFalse === null) {
+			$falseyWithoutFalse = TypeCombinator::remove(
+				StaticTypeFactory::falsey(),
+				new ConstantBooleanType(false),
+			);
+		}
+
+		return $falseyWithoutFalse;
 	}
 
 }

--- a/tests/Rules/DisallowedConstructs/DisallowedShortTernaryRuleTest.php
+++ b/tests/Rules/DisallowedConstructs/DisallowedShortTernaryRuleTest.php
@@ -21,11 +21,43 @@ class DisallowedShortTernaryRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/short-ternary.php'], [
 			[
 				'Short ternary operator is not allowed. Use null coalesce operator if applicable or consider using long ternary.',
-				3,
+				6,
 			],
 			[
 				'Short ternary operator is not allowed. Use null coalesce operator if applicable or consider using long ternary.',
-				4,
+				7,
+			],
+			[
+				'Short ternary operator is not allowed. Use null coalesce operator if applicable or consider using long ternary.',
+				13,
+			],
+			[
+				'Short ternary operator is not allowed. Use null coalesce operator if applicable or consider using long ternary.',
+				14,
+			],
+			[
+				'Short ternary operator is not allowed. Use null coalesce operator if applicable or consider using long ternary.',
+				31,
+			],
+			[
+				'Short ternary operator is not allowed. Use null coalesce operator if applicable or consider using long ternary.',
+				32,
+			],
+			[
+				'Short ternary operator is not allowed. Use null coalesce operator if applicable or consider using long ternary.',
+				37,
+			],
+			[
+				'Short ternary operator is not allowed. Use null coalesce operator if applicable or consider using long ternary.',
+				38,
+			],
+			[
+				'Short ternary operator is not allowed. Use null coalesce operator if applicable or consider using long ternary.',
+				49,
+			],
+			[
+				'Short ternary operator is not allowed. Use null coalesce operator if applicable or consider using long ternary.',
+				50,
 			],
 		]);
 	}

--- a/tests/Rules/DisallowedConstructs/data/short-ternary.php
+++ b/tests/Rules/DisallowedConstructs/data/short-ternary.php
@@ -1,5 +1,56 @@
 <?php
 
-$foo = 123 ?: 456;
-$bar = 123 ? : 456;
-$baz = 123 ? 456 : 789;
+/** @var int $cond */
+$cond = 123;
+
+$foo = $cond ?: 456;
+$bar = $cond ? : 456;
+$baz = $cond ? 456 : 789;
+
+/** @var int|false $cond */
+$cond = 123;
+
+$foo = $cond ?: 456;
+$bar = $cond ? : 456;
+
+/** @var positive-int|false $ */
+$cond = 123;
+
+$foo = $cond ?: 456;
+$bar = $cond ? : 456;
+
+/** @var object|false $ */
+$cond = 123;
+
+$foo = $cond ?: 456;
+$bar = $cond ? : 456;
+
+/** @var string|false $ */
+$cond = '123';
+
+$foo = $cond ?: 456;
+$bar = $cond ? : 456;
+
+/** @var non-empty-string|false $ */
+$cond = '123';
+
+$foo = $cond ?: 456;
+$bar = $cond ? : 456;
+
+/** @var non-falsy-string|false $ */
+$cond = '123';
+
+$foo = $cond ?: 456;
+$bar = $cond ? : 456;
+
+/** @var array|false $ */
+$cond = [123];
+
+$foo = $cond ?: 456;
+$bar = $cond ? : 456;
+
+/** @var non-empty-array|false $ */
+$cond = [123];
+
+$foo = $cond ?: 456;
+$bar = $cond ? : 456;


### PR DESCRIPTION
Hi @ondrejmirtes 

I recently encountered situation where short ternary could be considered useful, for instance when using `Datetime::createfromformat`. https://www.php.net/manual/en/datetime.createfromformat.php

Since the return type is `object|false` there is no risk writing
```
DateTime::createFromFormat(....) ?: $defaultValue
```
and this is way shorter than
```
$value = DateTime::createFromFormat(....);
if ($value === false) {
     $value = $defaultValue;
}
```
But in other cases I do like to forbid short ternary because things like 
```
$intOrFalse ?: $defaultValue
```
is risky, I might have forgot that `0` will end in the default value.

So if you're interested I see two solutions:
1) Relaxing the "forbid ternary" rules to allow `nonFalsey|false` conditions (and maybe updating the error message behind the bleeding edge tag)
2) Or introducing a config option to allow `nonFalsey|false` conditions (maybe you'll have a naming suggestion for this one ?), and when the option is enabled I think the error message should be changed too. (like "Short ternary is not allowed on non boolean falsey type. Use null coalesce operator if applicable or consider using long ternary.")

This is currently a POC which should be updated based on your preferences. :)

Looking at how sometimes some rules are loosen up (like in https://github.com/phpstan/phpstan-strict-rules/commit/8afd4af32bbff7b1f6df3d42bda45b2e661ba297), I think it could be ok to relax the forbid ternary rule without an option. But your call.

This would also close https://github.com/phpstan/phpstan-strict-rules/issues/268 (Should I assume that since you didn't close the issue, you're open to some suggestion ?)