### PR TITLE
Remove duplicate rules in `Readme.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 | `booleansInConditions`                 | Require booleans in `if`, `elseif`, ternary operator, after `!`, and on both sides of `&&` and `\|\|`.  |
 | `booleansInLoopConditions`             | Require booleans in `while` and `do while` loop conditions.                                             |
 | `numericOperandsInArithmeticOperators` | Require numeric operand in `+$var`, `-$var`, `$var++`, `$var--`, `++$var` and `--$var`. |
-| `numericOperandsInArithmeticOperators` | Require numeric operand in `$var++`, `$var--`, `++$var`and `--$var`.                                    |
 | `strictFunctionCalls`                  | These functions contain a `$strict` parameter for better type safety, it must be set to `true`:<br>* `in_array` (3rd parameter)<br>* `array_search` (3rd parameter)<br>* `array_keys` (3rd parameter; only if the 2nd parameter `$search_value` is provided)<br>* `base64_decode` (2nd parameter). |
 | `overwriteVariablesWithLoop`           | * Disallow overwriting variables with `foreach` key and value variables.<br>* Disallow overwriting variables with `for` loop initial assignment.                                                                   |
 | `switchConditionsMatchingType`         | Types in `switch` condition and `case` value must match. PHP compares them loosely by default and that can lead to  unexpected results. |


### PR DESCRIPTION
I noticed that the rule `numericOperandsInArithmeticOperators` is listed twice in the table.