### PR TITLE
Add operand types to DisallowedLooseComparisonRule error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 | `switchConditionsMatchingType`         | Types in `switch` condition and `case` value must match. PHP compares them loosely by default and that can lead to  unexpected results. |
 | `dynamicCallOnStaticMethod`            | Check that statically declared methods are called statically.                                           |
 | `disallowedEmpty`                      | Disallow `empty()` - it's a very loose comparison (see [manual](https://php.net/empty)), it's recommended to use more  strict one. |
+| `disallowedLooseComparison`            | Disallow loose comparison via `==` and `!=`. |
 | `disallowedShortTernary`               | Disallow short ternary operator (`?:`) - implies weak comparison, it's recommended to use null coalesce operator (`??`)  or ternary operator with strict condition. |
 | `noVariableVariables`                  | Disallow variable variables (`$$foo`, `$this->$method()` etc.).                                         |
 | `checkAlwaysTrueInstanceof`, `checkAlwaysTrueCheckTypeFunctionCall`, `checkAlwaysTrueStrictComparison` | Always true `instanceof`, type-checking `is_*` functions and strict comparisons `===`/`!==`. These checks can be turned off by setting `checkAlwaysTrueInstanceof`, `checkAlwaysTrueCheckTypeFunctionCall` and `checkAlwaysTrueStrictComparison` to false. |

--- a/rules.neon
+++ b/rules.neon
@@ -164,6 +164,8 @@ services:
 
 	-
 		class: PHPStan\Rules\DisallowedConstructs\DisallowedLooseComparisonRule
+		arguments:
+			includeOperandTypesInErrorMessage: %featureToggles.bleedingEdge%
 
 	-
 		class: PHPStan\Rules\BooleansInConditions\BooleanInBooleanAndRule

--- a/tests/Rules/DisallowedConstructs/DisallowedLooseComparisonRuleTest.php
+++ b/tests/Rules/DisallowedConstructs/DisallowedLooseComparisonRuleTest.php
@@ -11,13 +11,18 @@ use PHPStan\Testing\RuleTestCase;
 class DisallowedLooseComparisonRuleTest extends RuleTestCase
 {
 
+	private bool $includeOperandTypesInErrorMessage;
+
 	protected function getRule(): Rule
 	{
-		return new DisallowedLooseComparisonRule();
+		return new DisallowedLooseComparisonRule(
+			$this->includeOperandTypesInErrorMessage,
+		);
 	}
 
-	public function testRule(): void
+	public function testRuleWithoutOperandTypesInErrorMessage(): void
 	{
+		$this->includeOperandTypesInErrorMessage = false;
 		$this->analyse([__DIR__ . '/data/weak-comparison.php'], [
 			[
 				'Loose comparison via "==" is not allowed.',
@@ -27,6 +32,83 @@ class DisallowedLooseComparisonRuleTest extends RuleTestCase
 			[
 				'Loose comparison via "!=" is not allowed.',
 				5,
+				'Use strict comparison via "!==" instead.',
+			],
+			[
+				'Loose comparison via "==" is not allowed.',
+				8,
+				'Use strict comparison via "===" instead.',
+			],
+			[
+				'Loose comparison via "!=" is not allowed.',
+				10,
+				'Use strict comparison via "!==" instead.',
+			],
+			[
+				'Loose comparison via "==" is not allowed.',
+				13,
+				'Use strict comparison via "===" instead.',
+			],
+			[
+				'Loose comparison via "!=" is not allowed.',
+				15,
+				'Use strict comparison via "!==" instead.',
+			],
+			[
+				'Loose comparison via "==" is not allowed.',
+				18,
+				'Use strict comparison via "===" instead.',
+			],
+			[
+				'Loose comparison via "!=" is not allowed.',
+				20,
+				'Use strict comparison via "!==" instead.',
+			],
+		]);
+	}
+
+	public function testRuleWithOperandTypesInErrorMessage(): void
+	{
+		$this->includeOperandTypesInErrorMessage = true;
+		$this->analyse([__DIR__ . '/data/weak-comparison.php'], [
+			[
+				'Loose comparison via "==" between int and int is not allowed.',
+				3,
+				'Use strict comparison via "===" instead.',
+			],
+			[
+				'Loose comparison via "!=" between int and int is not allowed.',
+				5,
+				'Use strict comparison via "!==" instead.',
+			],
+			[
+				'Loose comparison via "==" between DateTime and float is not allowed.',
+				8,
+				'Use strict comparison via "===" instead.',
+			],
+			[
+				'Loose comparison via "!=" between float and DateTime is not allowed.',
+				10,
+				'Use strict comparison via "!==" instead.',
+			],
+			[
+				'Loose comparison via "==" between DateTime and null is not allowed.',
+				13,
+				'Use strict comparison via "===" instead.',
+			],
+			[
+				'Loose comparison via "!=" between null and DateTime is not allowed.',
+				15,
+				'Use strict comparison via "!==" instead.',
+			],
+			[
+				'Loose comparison via "==" between DateTime and DateTime is not allowed.',
+				18,
+				'Use strict comparison via "===" instead.',
+			],
+			[
+				'Loose comparison via "!=" between DateTime and DateTime is not allowed.',
+				20,
 				'Use strict comparison via "!==" instead.',
 			],
 		]);

--- a/tests/Rules/DisallowedConstructs/data/weak-comparison.php
+++ b/tests/Rules/DisallowedConstructs/data/weak-comparison.php
@@ -4,3 +4,18 @@ $bool1 = 123 == 456;
 $bool2 = 123 === 456;
 $bool3 = 123 != 456;
 $bool4 = 123 !== 456;
+
+$bool5 = new DateTime('now') == 1.23;
+$bool6 = new DateTime('now') === 1.23;
+$bool7 = 1.23 != new DateTime('now');
+$bool8 = 1.23 !== new DateTime('now');
+
+$bool9 = new DateTime('now') == null;
+$bool10 = new DateTime('now') === null;
+$bool11 = null != new DateTime('now');
+$bool12 = null !== new DateTime('now');
+
+$bool13 = new DateTime('now') == new DateTime('now');
+$bool14 = new DateTime('now') === new DateTime('now');
+$bool15 = new DateTime('now') != new DateTime('now');
+$bool16 = new DateTime('now') !== new DateTime('now');


### PR DESCRIPTION
This makes it possible to ignore `disallowedLooseComparison` issues for certain builtin PHP classes with overloaded comparison operators:

- `BcMath\Number`
- `DateTime` (Resolves https://github.com/phpstan/phpstan-strict-rules/issues/232)

Currently the error message doesn't include types:

```
Loose comparison via "==" is not allowed.
```

This adds operands types to make the errors ignorable:

```
Loose comparison via "==" between DateTime and DateTime is not allowed.
```