### PR TITLE
Allow literal string dynamic property

### DIFF
--- a/src/Rules/VariableVariables/VariablePropertyFetchRule.php
+++ b/src/Rules/VariableVariables/VariablePropertyFetchRule.php
@@ -44,6 +44,10 @@ class VariablePropertyFetchRule implements Rule
 			return [];
 		}
 
+		if ($scope->getType($node->name)->isLiteralString()->yes()) {
+			return [];
+		}
+
 		$fetchedOnType = $scope->getType($node->var);
 		foreach ($fetchedOnType->getObjectClassNames() as $referencedClass) {
 			if (!$this->reflectionProvider->hasClass($referencedClass)) {

--- a/tests/Rules/VariableVariables/data/properties.php
+++ b/tests/Rules/VariableVariables/data/properties.php
@@ -15,13 +15,14 @@ class Bar extends stdClass
 }
 
 function (stdClass $std, Foo $foo, Bar $bar) {
-	$str = 'str';
+	$str = sprintf('str%d', time());
 
 	$std->foo;
 	$std->$str;
 
 	$foo->foo;
 	$foo->$str;
+	$foo->{'str'};
 
 	$bar->foo;
 	$bar->$str;


### PR DESCRIPTION
In [JSON-LD](https://json-ld.org/), there are property names like `@type` which are accessible only via `$ld->{'@type'}` in PHP. These are not dynamic property accesses and shouldn't be reported as such.