### PR TITLE
Add keywords for static analysis in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
 	"license": [
 		"MIT"
 	],
+	"keywords": ["static analysis"],
 	"require": {
 		"php": "^7.4 || ^8.0",
 		"phpstan/phpstan": "^2.1.29"


### PR DESCRIPTION
Prevent installs in non-dev, similar to phpstan.

> The package you required is recommended to be placed in require-dev (because it is tagged as "static analysis") but you did not use --dev.