### PR TITLE
Allow BcMath\Number increment/decrement

### DIFF
--- a/src/Rules/Operators/OperatorRuleHelper.php
+++ b/src/Rules/Operators/OperatorRuleHelper.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Operators;
 
 use PhpParser\Node\Expr;
 use PHPStan\Analyser\Scope;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Type\Accessory\AccessoryNumericStringType;
 use PHPStan\Type\BenevolentUnionType;
@@ -12,6 +13,7 @@ use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
@@ -21,9 +23,12 @@ class OperatorRuleHelper
 
 	private RuleLevelHelper $ruleLevelHelper;
 
-	public function __construct(RuleLevelHelper $ruleLevelHelper)
+	private PhpVersion $phpVersion;
+
+	public function __construct(RuleLevelHelper $ruleLevelHelper, PhpVersion $phpVersion)
 	{
 		$this->ruleLevelHelper = $ruleLevelHelper;
+		$this->phpVersion = $phpVersion;
 	}
 
 	public function isValidForArithmeticOperation(Scope $scope, Expr $expr): bool
@@ -68,7 +73,13 @@ class OperatorRuleHelper
 
 	private function isSubtypeOfNumber(Scope $scope, Expr $expr): bool
 	{
-		$acceptedType = new UnionType([new IntegerType(), new FloatType(), new IntersectionType([new StringType(), new AccessoryNumericStringType()])]);
+		$acceptedTypes = [new IntegerType(), new FloatType(), new IntersectionType([new StringType(), new AccessoryNumericStringType()])];
+
+		if ($this->phpVersion->supportsBcMathNumberOperatorOverloading()) {
+			$acceptedTypes[] = new ObjectType('BcMath\Number');
+		}
+
+		$acceptedType = new UnionType($acceptedTypes);
 
 		$type = $this->ruleLevelHelper->findTypeToCheck(
 			$scope,

--- a/tests/Rules/Operators/OperandInArithmeticIncrementOrDecrementRuleTestCase.php
+++ b/tests/Rules/Operators/OperandInArithmeticIncrementOrDecrementRuleTestCase.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Operators;
 
+use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
@@ -18,6 +19,7 @@ abstract class OperandInArithmeticIncrementOrDecrementRuleTestCase extends RuleT
 		return $this->createRule(
 			new OperatorRuleHelper(
 				self::getContainer()->getByType(RuleLevelHelper::class),
+				self::getContainer()->getByType(PhpVersion::class),
 			),
 		);
 	}

--- a/tests/Rules/Operators/OperandInArithmeticIncrementOrDecrementRuleTestCase.php
+++ b/tests/Rules/Operators/OperandInArithmeticIncrementOrDecrementRuleTestCase.php
@@ -28,6 +28,14 @@ abstract class OperandInArithmeticIncrementOrDecrementRuleTestCase extends RuleT
 	}
 
 	/**
+	 * @requires PHP >= 8.4
+	 */
+	public function testRuleWithBcMath(): void
+	{
+		$this->analyse([__DIR__ . '/data/increment-decrement-bcmath.php'], $this->getExpectedErrorsWithBcMath());
+	}
+
+	/**
 	 * @return T
 	 */
 	abstract protected function createRule(OperatorRuleHelper $helper): Rule;
@@ -36,5 +44,10 @@ abstract class OperandInArithmeticIncrementOrDecrementRuleTestCase extends RuleT
 	 * @return list<array{0: string, 1: int, 2?: string}>
 	 */
 	abstract protected function getExpectedErrors(): array;
+
+	/**
+	 * @return list<array{0: string, 1: int, 2?: string}>
+	 */
+	abstract protected function getExpectedErrorsWithBcMath(): array;
 
 }

--- a/tests/Rules/Operators/OperandInArithmeticPostDecrementRuleTest.php
+++ b/tests/Rules/Operators/OperandInArithmeticPostDecrementRuleTest.php
@@ -49,12 +49,7 @@ class OperandInArithmeticPostDecrementRuleTest extends OperandInArithmeticIncrem
 	 */
 	protected function getExpectedErrorsWithBcMath(): array
 	{
-		return [
-			[
-				'Only numeric types are allowed in post-decrement, BcMath\Number given.',
-				8,
-			],
-		];
+		return [];
 	}
 
 }

--- a/tests/Rules/Operators/OperandInArithmeticPostDecrementRuleTest.php
+++ b/tests/Rules/Operators/OperandInArithmeticPostDecrementRuleTest.php
@@ -44,4 +44,17 @@ class OperandInArithmeticPostDecrementRuleTest extends OperandInArithmeticIncrem
 		];
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function getExpectedErrorsWithBcMath(): array
+	{
+		return [
+			[
+				'Only numeric types are allowed in post-decrement, BcMath\Number given.',
+				8,
+			],
+		];
+	}
+
 }

--- a/tests/Rules/Operators/OperandInArithmeticPostIncrementRuleTest.php
+++ b/tests/Rules/Operators/OperandInArithmeticPostIncrementRuleTest.php
@@ -45,12 +45,7 @@ class OperandInArithmeticPostIncrementRuleTest extends OperandInArithmeticIncrem
 	 */
 	protected function getExpectedErrorsWithBcMath(): array
 	{
-		return [
-			[
-				'Only numeric types are allowed in post-increment, BcMath\Number given.',
-				12,
-			],
-		];
+		return [];
 	}
 
 }

--- a/tests/Rules/Operators/OperandInArithmeticPostIncrementRuleTest.php
+++ b/tests/Rules/Operators/OperandInArithmeticPostIncrementRuleTest.php
@@ -40,4 +40,17 @@ class OperandInArithmeticPostIncrementRuleTest extends OperandInArithmeticIncrem
 		];
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function getExpectedErrorsWithBcMath(): array
+	{
+		return [
+			[
+				'Only numeric types are allowed in post-increment, BcMath\Number given.',
+				12,
+			],
+		];
+	}
+
 }

--- a/tests/Rules/Operators/OperandInArithmeticPreDecrementRuleTest.php
+++ b/tests/Rules/Operators/OperandInArithmeticPreDecrementRuleTest.php
@@ -44,4 +44,17 @@ class OperandInArithmeticPreDecrementRuleTest extends OperandInArithmeticIncreme
 		];
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function getExpectedErrorsWithBcMath(): array
+	{
+		return [
+			[
+				'Only numeric types are allowed in pre-decrement, BcMath\Number given.',
+				16,
+			],
+		];
+	}
+
 }

--- a/tests/Rules/Operators/OperandInArithmeticPreDecrementRuleTest.php
+++ b/tests/Rules/Operators/OperandInArithmeticPreDecrementRuleTest.php
@@ -49,12 +49,7 @@ class OperandInArithmeticPreDecrementRuleTest extends OperandInArithmeticIncreme
 	 */
 	protected function getExpectedErrorsWithBcMath(): array
 	{
-		return [
-			[
-				'Only numeric types are allowed in pre-decrement, BcMath\Number given.',
-				16,
-			],
-		];
+		return [];
 	}
 
 }

--- a/tests/Rules/Operators/OperandInArithmeticPreIncrementRuleTest.php
+++ b/tests/Rules/Operators/OperandInArithmeticPreIncrementRuleTest.php
@@ -40,4 +40,17 @@ class OperandInArithmeticPreIncrementRuleTest extends OperandInArithmeticIncreme
 		];
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function getExpectedErrorsWithBcMath(): array
+	{
+		return [
+			[
+				'Only numeric types are allowed in pre-increment, BcMath\Number given.',
+				20,
+			],
+		];
+	}
+
 }

--- a/tests/Rules/Operators/OperandInArithmeticPreIncrementRuleTest.php
+++ b/tests/Rules/Operators/OperandInArithmeticPreIncrementRuleTest.php
@@ -45,12 +45,7 @@ class OperandInArithmeticPreIncrementRuleTest extends OperandInArithmeticIncreme
 	 */
 	protected function getExpectedErrorsWithBcMath(): array
 	{
-		return [
-			[
-				'Only numeric types are allowed in pre-increment, BcMath\Number given.',
-				20,
-			],
-		];
+		return [];
 	}
 
 }

--- a/tests/Rules/Operators/OperandInArithmeticUnaryMinusRuleTest.php
+++ b/tests/Rules/Operators/OperandInArithmeticUnaryMinusRuleTest.php
@@ -31,4 +31,12 @@ class OperandInArithmeticUnaryMinusRuleTest extends RuleTestCase
 		]);
 	}
 
+	/**
+	 * @requires PHP >= 8.4
+	 */
+	public function testRuleWithBcMath(): void
+	{
+		$this->analyse([__DIR__ . '/data/operators-bcmath.php'], []);
+	}
+
 }

--- a/tests/Rules/Operators/OperandInArithmeticUnaryMinusRuleTest.php
+++ b/tests/Rules/Operators/OperandInArithmeticUnaryMinusRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Operators;
 
+use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
@@ -17,6 +18,7 @@ class OperandInArithmeticUnaryMinusRuleTest extends RuleTestCase
 		return new OperandInArithmeticUnaryMinusRule(
 			new OperatorRuleHelper(
 				self::getContainer()->getByType(RuleLevelHelper::class),
+				self::getContainer()->getByType(PhpVersion::class),
 			),
 		);
 	}

--- a/tests/Rules/Operators/OperandInArithmeticUnaryPlusRuleTest.php
+++ b/tests/Rules/Operators/OperandInArithmeticUnaryPlusRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Operators;
 
+use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
@@ -17,6 +18,7 @@ class OperandInArithmeticUnaryPlusRuleTest extends RuleTestCase
 		return new OperandInArithmeticUnaryPlusRule(
 			new OperatorRuleHelper(
 				self::getContainer()->getByType(RuleLevelHelper::class),
+				self::getContainer()->getByType(PhpVersion::class),
 			),
 		);
 	}

--- a/tests/Rules/Operators/OperandInArithmeticUnaryPlusRuleTest.php
+++ b/tests/Rules/Operators/OperandInArithmeticUnaryPlusRuleTest.php
@@ -31,4 +31,12 @@ class OperandInArithmeticUnaryPlusRuleTest extends RuleTestCase
 		]);
 	}
 
+	/**
+	 * @requires PHP >= 8.4
+	 */
+	public function testRuleWithBcMath(): void
+	{
+		$this->analyse([__DIR__ . '/data/operators-bcmath.php'], []);
+	}
+
 }

--- a/tests/Rules/Operators/OperandsInArithmeticAdditionRuleTest.php
+++ b/tests/Rules/Operators/OperandsInArithmeticAdditionRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Operators;
 
+use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
@@ -19,6 +20,7 @@ class OperandsInArithmeticAdditionRuleTest extends RuleTestCase
 		return new OperandsInArithmeticAdditionRule(
 			new OperatorRuleHelper(
 				self::getContainer()->getByType(RuleLevelHelper::class),
+				self::getContainer()->getByType(PhpVersion::class),
 			),
 		);
 	}

--- a/tests/Rules/Operators/OperandsInArithmeticAdditionRuleTest.php
+++ b/tests/Rules/Operators/OperandsInArithmeticAdditionRuleTest.php
@@ -60,4 +60,25 @@ class OperandsInArithmeticAdditionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/operators.php'], $messages);
 	}
 
+	/**
+	 * @requires PHP >= 8.4
+	 */
+	public function testRuleWithBcMath(): void
+	{
+		$this->analyse([__DIR__ . '/data/operators-bcmath.php'], [
+			[
+				'Only numeric types are allowed in +, null given on the right side.',
+				36,
+			],
+			[
+				'Only numeric types are allowed in +, null given on the left side.',
+				37,
+			],
+			[
+				'Only numeric types are allowed in +, null given on the right side.',
+				157,
+			],
+		]);
+	}
+
 }

--- a/tests/Rules/Operators/OperandsInArithmeticDivisionRuleTest.php
+++ b/tests/Rules/Operators/OperandsInArithmeticDivisionRuleTest.php
@@ -43,4 +43,25 @@ class OperandsInArithmeticDivisionRuleTest extends RuleTestCase
 		]);
 	}
 
+	/**
+	 * @requires PHP >= 8.4
+	 */
+	public function testRuleWithBcMath(): void
+	{
+		$this->analyse([__DIR__ . '/data/operators-bcmath.php'], [
+			[
+				'Only numeric types are allowed in /, null given on the right side.',
+				96,
+			],
+			[
+				'Only numeric types are allowed in /, null given on the left side.',
+				97,
+			],
+			[
+				'Only numeric types are allowed in /, null given on the right side.',
+				217,
+			],
+		]);
+	}
+
 }

--- a/tests/Rules/Operators/OperandsInArithmeticDivisionRuleTest.php
+++ b/tests/Rules/Operators/OperandsInArithmeticDivisionRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Operators;
 
+use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
@@ -17,6 +18,7 @@ class OperandsInArithmeticDivisionRuleTest extends RuleTestCase
 		return new OperandsInArithmeticDivisionRule(
 			new OperatorRuleHelper(
 				self::getContainer()->getByType(RuleLevelHelper::class),
+				self::getContainer()->getByType(PhpVersion::class),
 			),
 		);
 	}

--- a/tests/Rules/Operators/OperandsInArithmeticExponentiationRuleTest.php
+++ b/tests/Rules/Operators/OperandsInArithmeticExponentiationRuleTest.php
@@ -43,4 +43,25 @@ class OperandsInArithmeticExponentiationRuleTest extends RuleTestCase
 		]);
 	}
 
+	/**
+	 * @requires PHP >= 8.4
+	 */
+	public function testRuleWithBcMath(): void
+	{
+		$this->analyse([__DIR__ . '/data/operators-bcmath.php'], [
+			[
+				'Only numeric types are allowed in **, null given on the right side.',
+				116,
+			],
+			[
+				'Only numeric types are allowed in **, null given on the left side.',
+				117,
+			],
+			[
+				'Only numeric types are allowed in **, null given on the right side.',
+				237,
+			],
+		]);
+	}
+
 }

--- a/tests/Rules/Operators/OperandsInArithmeticExponentiationRuleTest.php
+++ b/tests/Rules/Operators/OperandsInArithmeticExponentiationRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Operators;
 
+use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
@@ -17,6 +18,7 @@ class OperandsInArithmeticExponentiationRuleTest extends RuleTestCase
 		return new OperandsInArithmeticExponentiationRule(
 			new OperatorRuleHelper(
 				self::getContainer()->getByType(RuleLevelHelper::class),
+				self::getContainer()->getByType(PhpVersion::class),
 			),
 		);
 	}

--- a/tests/Rules/Operators/OperandsInArithmeticModuloRuleTest.php
+++ b/tests/Rules/Operators/OperandsInArithmeticModuloRuleTest.php
@@ -43,4 +43,25 @@ class OperandsInArithmeticModuloRuleTest extends RuleTestCase
 		]);
 	}
 
+	/**
+	 * @requires PHP >= 8.4
+	 */
+	public function testRuleWithBcMath(): void
+	{
+		$this->analyse([__DIR__ . '/data/operators-bcmath.php'], [
+			[
+				'Only numeric types are allowed in %, null given on the right side.',
+				136,
+			],
+			[
+				'Only numeric types are allowed in %, null given on the left side.',
+				137,
+			],
+			[
+				'Only numeric types are allowed in %, null given on the right side.',
+				257,
+			],
+		]);
+	}
+
 }

--- a/tests/Rules/Operators/OperandsInArithmeticModuloRuleTest.php
+++ b/tests/Rules/Operators/OperandsInArithmeticModuloRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Operators;
 
+use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
@@ -17,6 +18,7 @@ class OperandsInArithmeticModuloRuleTest extends RuleTestCase
 		return new OperandsInArithmeticModuloRule(
 			new OperatorRuleHelper(
 				self::getContainer()->getByType(RuleLevelHelper::class),
+				self::getContainer()->getByType(PhpVersion::class),
 			),
 		);
 	}

--- a/tests/Rules/Operators/OperandsInArithmeticMultiplicationRuleTest.php
+++ b/tests/Rules/Operators/OperandsInArithmeticMultiplicationRuleTest.php
@@ -43,4 +43,25 @@ class OperandsInArithmeticMultiplicationRuleTest extends RuleTestCase
 		]);
 	}
 
+	/**
+	 * @requires PHP >= 8.4
+	 */
+	public function testRuleWithBcMath(): void
+	{
+		$this->analyse([__DIR__ . '/data/operators-bcmath.php'], [
+			[
+				'Only numeric types are allowed in *, null given on the right side.',
+				76,
+			],
+			[
+				'Only numeric types are allowed in *, null given on the left side.',
+				77,
+			],
+			[
+				'Only numeric types are allowed in *, null given on the right side.',
+				197,
+			],
+		]);
+	}
+
 }

--- a/tests/Rules/Operators/OperandsInArithmeticMultiplicationRuleTest.php
+++ b/tests/Rules/Operators/OperandsInArithmeticMultiplicationRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Operators;
 
+use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
@@ -17,6 +18,7 @@ class OperandsInArithmeticMultiplicationRuleTest extends RuleTestCase
 		return new OperandsInArithmeticMultiplicationRule(
 			new OperatorRuleHelper(
 				self::getContainer()->getByType(RuleLevelHelper::class),
+				self::getContainer()->getByType(PhpVersion::class),
 			),
 		);
 	}

--- a/tests/Rules/Operators/OperandsInArithmeticSubtractionRuleTest.php
+++ b/tests/Rules/Operators/OperandsInArithmeticSubtractionRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Operators;
 
+use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
@@ -17,6 +18,7 @@ class OperandsInArithmeticSubtractionRuleTest extends RuleTestCase
 		return new OperandsInArithmeticSubtractionRule(
 			new OperatorRuleHelper(
 				self::getContainer()->getByType(RuleLevelHelper::class),
+				self::getContainer()->getByType(PhpVersion::class),
 			),
 		);
 	}

--- a/tests/Rules/Operators/OperandsInArithmeticSubtractionRuleTest.php
+++ b/tests/Rules/Operators/OperandsInArithmeticSubtractionRuleTest.php
@@ -43,4 +43,25 @@ class OperandsInArithmeticSubtractionRuleTest extends RuleTestCase
 		]);
 	}
 
+	/**
+	 * @requires PHP >= 8.4
+	 */
+	public function testRuleWithBcMath(): void
+	{
+		$this->analyse([__DIR__ . '/data/operators-bcmath.php'], [
+			[
+				'Only numeric types are allowed in -, null given on the right side.',
+				56,
+			],
+			[
+				'Only numeric types are allowed in -, null given on the left side.',
+				57,
+			],
+			[
+				'Only numeric types are allowed in -, null given on the right side.',
+				177,
+			],
+		]);
+	}
+
 }

--- a/tests/Rules/Operators/data/increment-decrement-bcmath.php
+++ b/tests/Rules/Operators/data/increment-decrement-bcmath.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Operators;
+
+use BcMath\Number;
+
+function testPostDecrement(Number $x): Number {
+        return $x--;
+}
+
+function testPostIncrement(Number $x): Number {
+        return $x++;
+}
+
+function testPreDecrement(Number $x): Number {
+        return --$x;
+}
+
+function testPreIncrement(Number $x): Number {
+        return ++$x;
+}

--- a/tests/Rules/Operators/data/operators-bcmath.php
+++ b/tests/Rules/Operators/data/operators-bcmath.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace Operators;
+
+use BcMath\Number;
+
+$number = new Number(123);
+
+$int = 123;
+$float = 123.456;
+$array = [];
+$string = '123';
+$object = new stdClass();
+$null = null;
+
+/** @var int|float $intOrFloat */
+$intOrFloat = foo();
+
+/** @var numeric-string $numericString */
+$numericString = doFoo();
+
+/** @var mixed $mixed */
+$mixed = getMixed();
+
+$number + $number;
+$number + $int;
+$int + $number;
+$number + $float;
+$float + $number;
+$number + $array;
+$array + $number;
+$number + $string;
+$string + $number;
+$number + $object;
+$object + $number;
+$number + $null;
+$null + $number;
+$number + $intOrFloat;
+$intOrFloat + $number;
+$number + $numericString;
+$numericString + $number;
+$number + $mixed;
+$mixed + $number;
+
+$number - $number;
+$number - $int;
+$int - $number;
+$number - $float;
+$float - $number;
+$number - $array;
+$array - $number;
+$number - $string;
+$string - $number;
+$number - $object;
+$object - $number;
+$number - $null;
+$null - $number;
+$number - $intOrFloat;
+$intOrFloat - $number;
+$number - $numericString;
+$numericString - $number;
+$number - $mixed;
+$mixed - $number;
+
+$number * $number;
+$number * $int;
+$int * $number;
+$number * $float;
+$float * $number;
+$number * $array;
+$array * $number;
+$number * $string;
+$string * $number;
+$number * $object;
+$object * $number;
+$number * $null;
+$null * $number;
+$number * $intOrFloat;
+$intOrFloat * $number;
+$number * $numericString;
+$numericString * $number;
+$number * $mixed;
+$mixed * $number;
+
+$number / $number;
+$number / $int;
+$int / $number;
+$number / $float;
+$float / $number;
+$number / $array;
+$array / $number;
+$number / $string;
+$string / $number;
+$number / $object;
+$object / $number;
+$number / $null;
+$null / $number;
+$number / $intOrFloat;
+$intOrFloat / $number;
+$number / $numericString;
+$numericString / $number;
+$number / $mixed;
+$mixed / $number;
+
+$number ** $number;
+$number ** $int;
+$int ** $number;
+$number ** $float;
+$float ** $number;
+$number ** $array;
+$array ** $number;
+$number ** $string;
+$string ** $number;
+$number ** $object;
+$object ** $number;
+$number ** $null;
+$null ** $number;
+$number ** $intOrFloat;
+$intOrFloat ** $number;
+$number ** $numericString;
+$numericString ** $number;
+$number ** $mixed;
+$mixed ** $number;
+
+$number % $number;
+$number % $int;
+$int % $number;
+$number % $float;
+$float % $number;
+$number % $array;
+$array % $number;
+$number % $string;
+$string % $number;
+$number % $object;
+$object % $number;
+$number % $null;
+$null % $number;
+$number % $intOrFloat;
+$intOrFloat % $number;
+$number % $numericString;
+$numericString % $number;
+$number % $mixed;
+$mixed % $number;
+
+$number += $number;
+$number += $int;
+$int += $number;
+$number += $float;
+$float += $number;
+$number += $float;
+$number += $array;
+$array += $number;
+$number += $string;
+$string += $number;
+$number += $object;
+$object += $number;
+$number += $null;
+$number += $intOrFloat;
+$intOrFloat += $number;
+$number += $numericString;
+$numericString += $number;
+$number += $mixed;
+$mixed += $number;
+
+$number -= $number;
+$number -= $int;
+$int -= $number;
+$number -= $float;
+$float -= $number;
+$number -= $float;
+$number -= $array;
+$array -= $number;
+$number -= $string;
+$string -= $number;
+$number -= $object;
+$object -= $number;
+$number -= $null;
+$number -= $intOrFloat;
+$intOrFloat -= $number;
+$number -= $numericString;
+$numericString -= $number;
+$number -= $mixed;
+$mixed -= $number;
+
+$number *= $number;
+$number *= $int;
+$int *= $number;
+$number *= $float;
+$float *= $number;
+$number *= $float;
+$number *= $array;
+$array *= $number;
+$number *= $string;
+$string *= $number;
+$number *= $object;
+$object *= $number;
+$number *= $null;
+$number *= $intOrFloat;
+$intOrFloat *= $number;
+$number *= $numericString;
+$numericString *= $number;
+$number *= $mixed;
+$mixed *= $number;
+
+$number /= $number;
+$number /= $int;
+$int /= $number;
+$number /= $float;
+$float /= $number;
+$number /= $float;
+$number /= $array;
+$array /= $number;
+$number /= $string;
+$string /= $number;
+$number /= $object;
+$object /= $number;
+$number /= $null;
+$number /= $intOrFloat;
+$intOrFloat /= $number;
+$number /= $numericString;
+$numericString /= $number;
+$number /= $mixed;
+$mixed /= $number;
+
+$number **= $number;
+$number **= $int;
+$int **= $number;
+$number **= $float;
+$float **= $number;
+$number **= $float;
+$number **= $array;
+$array **= $number;
+$number **= $string;
+$string **= $number;
+$number **= $object;
+$object **= $number;
+$number **= $null;
+$number **= $intOrFloat;
+$intOrFloat **= $number;
+$number **= $numericString;
+$numericString **= $number;
+$number **= $mixed;
+$mixed **= $number;
+
+$number %= $number;
+$number %= $int;
+$int %= $number;
+$number %= $float;
+$float %= $number;
+$number %= $float;
+$number %= $array;
+$array %= $number;
+$number %= $string;
+$string %= $number;
+$number %= $object;
+$object %= $number;
+$number %= $null;
+$number %= $intOrFloat;
+$intOrFloat %= $number;
+$number %= $numericString;
+$numericString %= $number;
+$number %= $mixed;
+$mixed %= $number;
+
++$number;
+
+-$number;


### PR DESCRIPTION
This allows `++`/`--` on BcMath\Number objects when using strict rules.

See https://phpstan.org/r/f3cd9326-5435-4000-b173-9e143d745acb

Related to https://github.com/phpstan/phpstan/issues/13965

Would be nice to include tests for PHP < 8.4, but the tests don't emit any errors because type `BcMath\Number` is not found. If there's a way to inject a dummy `BcMath\Number` class then I think it could be done?