### PR TITLE
Fix false positive UselessCast for `(void)` cast on `#[\NoDiscard]` calls

### DIFF
--- a/src/Rules/Cast/UselessCastRule.php
+++ b/src/Rules/Cast/UselessCastRule.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Cast;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Cast;
+use PhpParser\Node\Expr\Cast\Void_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -38,6 +39,10 @@ class UselessCastRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
+		if ($node instanceof Void_) {
+			return [];
+		}
+
 		$castType = $scope->getType($node);
 		if ($castType instanceof ErrorType) {
 			return [];

--- a/tests/Rules/Cast/UselessCastRuleTest.php
+++ b/tests/Rules/Cast/UselessCastRuleTest.php
@@ -89,4 +89,10 @@ class UselessCastRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug14565(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-14565.php'], []);
+	}
+
 }

--- a/tests/Rules/Cast/data/bug-14565.php
+++ b/tests/Rules/Cast/data/bug-14565.php
@@ -1,0 +1,18 @@
+<?php // lint >= 8.5
+
+namespace Bug14565;
+
+class Foo
+{
+
+	#[\NoDiscard]
+	public function bar(): int
+	{
+		return 1;
+	}
+
+}
+
+function (Foo $foo): void {
+	(void) $foo->bar();
+};


### PR DESCRIPTION
The PHP 8.5 `(void)` cast exists specifically to discard a value and
silence `#[\NoDiscard]` warnings; it is never useless by definition.

Closes https://github.com/phpstan/phpstan/issues/14565