### PR TITLE
Add collision-detector.json to export-ignore in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,4 @@ CLAUDE.md export-ignore
 Makefile export-ignore
 phpstan.neon export-ignore
 phpunit.xml export-ignore
+collision-detector.json export-ignore


### PR DESCRIPTION
Current archive targets other than src/ will be as follows:
```bash
gh api repos/phpstan/phpstan-strict-rules/tarball/HEAD | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -vE '^src/' | sort
```

```
collision-detector.json
composer.json
LICENSE
README.md
rules.neon
```

With this PR, the archive targets other than src/ will be as follows:
```bash
gh api repos/sasezaki/phpstan-strict-rules/tarball/patch-gitattributes | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -vE '^src/' | sort
```

```
composer.json
LICENSE
README.md
rules.neon
```

Changes:
- Added `collision-detector.json export-ignore`
  - `collision-detector.json`: Configuration for `shipmonk/name-collision-detector` (a dev tool); not needed by package consumers.
