### PR TITLE
Error on `unserialize()` without `allowed_classes` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 | `strictArrayFilter`                    | Require `array_filter()` to have a callback parameter to avoid loose comparison semantics.              |
 | `illegalConstructorMethodCall`         | Disallow calling `__construct()` on an existing object or as a static call outside of parent constructor. |
 | `closureUsesThis`                      | Closure should use `$this` directly instead of using `$this` variable indirectly.                       |
+| `unserializeAllowedClasses`            | Calls to `unserialize()` must include the `allowed_classes` option.                                     |
 
 Additional rules are coming in subsequent releases!
 
@@ -74,6 +75,7 @@ parameters:
 		disallowedShortTernary: false
 		overwriteVariablesWithLoop: false
 		closureUsesThis: false
+		unserializeAllowedClasses: false
 		matchingInheritedMethodNames: false
 		numericOperandsInArithmeticOperators: false
 		strictFunctionCalls: false

--- a/rules.neon
+++ b/rules.neon
@@ -26,6 +26,7 @@ parameters:
 		disallowedShortTernary: %strictRules.allRules%
 		overwriteVariablesWithLoop: %strictRules.allRules%
 		closureUsesThis: %strictRules.allRules%
+		unserializeAllowedClasses: %strictRules.allRules%
 		matchingInheritedMethodNames: %strictRules.allRules%
 		numericOperandsInArithmeticOperators: %strictRules.allRules%
 		strictFunctionCalls: %strictRules.allRules%
@@ -49,6 +50,7 @@ parametersSchema:
 		disallowedShortTernary: anyOf(bool(), arrayOf(bool()))
 		overwriteVariablesWithLoop: anyOf(bool(), arrayOf(bool()))
 		closureUsesThis: anyOf(bool(), arrayOf(bool()))
+		unserializeAllowedClasses: anyOf(bool(), arrayOf(bool()))
 		matchingInheritedMethodNames: anyOf(bool(), arrayOf(bool()))
 		numericOperandsInArithmeticOperators: anyOf(bool(), arrayOf(bool()))
 		strictFunctionCalls: anyOf(bool(), arrayOf(bool()))
@@ -98,6 +100,8 @@ conditionalTags:
 		phpstan.rules.rule: %strictRules.strictArrayFilter%
 	PHPStan\Rules\Functions\ClosureUsesThisRule:
 		phpstan.rules.rule: %strictRules.closureUsesThis%
+	PHPStan\Rules\Functions\UnserializeAllowedClassesRule:
+		phpstan.rules.rule: %strictRules.unserializeAllowedClasses%
 	PHPStan\Rules\Methods\WrongCaseOfInheritedMethodRule:
 		phpstan.rules.rule: %strictRules.matchingInheritedMethodNames%
 	PHPStan\Rules\Operators\OperandInArithmeticPostDecrementRule:
@@ -228,6 +232,9 @@ services:
 
 	-
 		class: PHPStan\Rules\Functions\ClosureUsesThisRule
+
+	-
+		class: PHPStan\Rules\Functions\UnserializeAllowedClassesRule
 
 	-
 		class: PHPStan\Rules\Methods\WrongCaseOfInheritedMethodRule

--- a/src/Rules/Functions/UnserializeAllowedClassesRule.php
+++ b/src/Rules/Functions/UnserializeAllowedClassesRule.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Functions;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use function count;
+use function in_array;
+use function strtolower;
+
+/** @implements Rule<FuncCall> */
+class UnserializeAllowedClassesRule implements Rule
+{
+
+	public function getNodeType(): string
+	{
+		return FuncCall::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!$node->name instanceof Node\Name) {
+			return [];
+		}
+
+		if (!in_array(strtolower((string) $node->name), ['unserialize'], true)) {
+			return [];
+		}
+
+		$args = $node->getArgs();
+
+		if (count($args) < 2) {
+			return [
+				RuleErrorBuilder::message(
+					'unserialize() called without the $options argument. Always pass '
+					. "['allowed_classes' => false] or an explicit list of safe classes. "
+					. "If you truly need to allow all classes, pass ['allowed_classes' => true] "
+					. 'to make that decision explicit.',
+				)
+					->identifier('unserialize.allowedClasses')
+					->build(),
+			];
+		}
+
+		$optionsArg = $args[1]->value;
+
+		if (!$optionsArg instanceof Node\Expr\Array_) {
+			return [];
+		}
+
+		foreach ($optionsArg->items as $item) {
+			if ($item === null) {
+				continue;
+			}
+
+			$key = $item->key;
+			if (!$key instanceof Node\Scalar\String_) {
+				continue;
+			}
+
+			if ($key->value === 'allowed_classes') {
+				return [];
+			}
+		}
+
+		return [
+			RuleErrorBuilder::message(
+				"unserialize() called without the 'allowed_classes' key in \$options. "
+				. "Always pass ['allowed_classes' => false] or an explicit list of safe classes. "
+				. "If you truly need to allow all classes, pass ['allowed_classes' => true] "
+				. 'to make that decision explicit.',
+			)
+				->identifier('unserialize.allowedClasses')
+				->build(),
+		];
+	}
+
+}

--- a/tests/Rules/Functions/UnserializeAllowedClassesRuleTest.php
+++ b/tests/Rules/Functions/UnserializeAllowedClassesRuleTest.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Functions;
+
+use PHPStan\Testing\RuleTestCase;
+
+/** @extends RuleTestCase<UnserializeAllowedClassesRule> */
+class UnserializeAllowedClassesRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): UnserializeAllowedClassesRule
+	{
+		return new UnserializeAllowedClassesRule();
+	}
+
+	public function testViolations(): void
+	{
+		$this->analyse([__DIR__ . '/data/unserialize-usages.php'], [
+			[
+				"unserialize() called without the \$options argument. Always pass ['allowed_classes' => false] or an explicit list of safe classes. If you truly need to allow all classes, pass ['allowed_classes' => true] to make that decision explicit.",
+				10,
+			],
+			[
+				"unserialize() called without the 'allowed_classes' key in \$options. Always pass ['allowed_classes' => false] or an explicit list of safe classes. If you truly need to allow all classes, pass ['allowed_classes' => true] to make that decision explicit.",
+				15,
+			],
+			[
+				"unserialize() called without the 'allowed_classes' key in \$options. Always pass ['allowed_classes' => false] or an explicit list of safe classes. If you truly need to allow all classes, pass ['allowed_classes' => true] to make that decision explicit.",
+				20,
+			],
+		]);
+	}
+
+	public function testNoErrors(): void
+	{
+		$this->analyse([__DIR__ . '/data/unserialize-good-usages.php'], []);
+	}
+
+}

--- a/tests/Rules/Functions/data/unserialize-good-usages.php
+++ b/tests/Rules/Functions/data/unserialize-good-usages.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace UnserializeAllowedClasses;
+
+final class UnserializeUsagesOk
+{
+
+	/** @return array<string, mixed> */
+	public function allowedClassesFalse(string $data): array
+	{
+		/** @var array<string, mixed> $result */
+		$result = unserialize($data, ['allowed_classes' => false]);
+
+		return $result;
+	}
+
+	public function allowedClassesExplicitTrue(string $data): mixed
+	{
+		return unserialize($data, ['allowed_classes' => true]);
+	}
+
+	public function allowedClassesList(string $data): mixed
+	{
+		return unserialize($data, ['allowed_classes' => [\stdClass::class]]);
+	}
+
+	public function dynamicOptions(string $data, mixed $options): mixed
+	{
+		return unserialize($data, $options);
+	}
+
+}

--- a/tests/Rules/Functions/data/unserialize-usages.php
+++ b/tests/Rules/Functions/data/unserialize-usages.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types = 1);
+
+namespace UnserializeAllowedClasses;
+
+final class UnserializeUsages
+{
+
+	public function noOptions(string $data): mixed
+	{
+		return unserialize($data);
+	}
+
+	public function emptyOptions(string $data): mixed
+	{
+		return unserialize($data, []);
+	}
+
+	public function optionsWithoutAllowedClasses(string $data): mixed
+	{
+		return unserialize($data, ['some_other_key' => true]);
+	}
+
+	/** @return array<string, mixed> */
+	public function allowedClassesFalse(string $data): array
+	{
+		/** @var array<string, mixed> $result */
+		$result = unserialize($data, ['allowed_classes' => false]);
+
+		return $result;
+	}
+
+	/** @return array<string, mixed> */
+	public function allowedClassesExplicitTrue(string $data): array
+	{
+		/** @var array<string, mixed> $result */
+		$result = unserialize($data, ['allowed_classes' => true]);
+
+		return $result;
+	}
+
+	public function allowedClassesList(string $data): mixed
+	{
+		return unserialize($data, ['allowed_classes' => [\stdClass::class]]);
+	}
+
+	public function dynamicOptions(string $data, mixed $options): mixed
+	{
+		return unserialize($data, $options);
+	}
+
+}


### PR DESCRIPTION
Calling `unserialize()` on a payload with serialized objects might trigger the autoloader on arbitrary classes. Furthermore, the execution of magic `__unserialize()` methods can be forced via the payload. The consequence of course is that we should not `unserialize()` data from untrusted sources. 🫣 

And if we really need to use `unserialize()`, I'd like the call to be hardened if possible. Because of that, I'd like to enforce the option `allowed_classes` to be set. The rule this PR adds does exactly that: it checks if the option is present.

The developer then has the option to:

* Set the option to `false` in order to forbid any classes to be unserialized.
* Set the option to a list of classes that they expect and allow in the payload.
* Set the option to `true` to allow all classes.

The latter is of course equivalent to the unsafe default, but the developer is forced to make that decision explicit.

I found this kind of rule helpful, so I wanted to share it, hoping it's helpful for others as well.