### PR TITLE
Report loop variable overwrites only for variables still in use

### DIFF
--- a/src/Rules/ForLoop/OverwriteVariablesWithForLoopInitRule.php
+++ b/src/Rules/ForLoop/OverwriteVariablesWithForLoopInitRule.php
@@ -3,72 +3,43 @@
 namespace PHPStan\Rules\ForLoop;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Stmt\For_;
 use PHPStan\Analyser\Scope;
-use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Node\VariableWritesNode;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use function is_string;
 use function sprintf;
 
 /**
- * @implements Rule<For_>
+ * @implements Rule<VariableWritesNode>
  */
 class OverwriteVariablesWithForLoopInitRule implements Rule
 {
 
 	public function getNodeType(): string
 	{
-		return For_::class;
+		return VariableWritesNode::class;
 	}
 
 	public function processNode(Node $node, Scope $scope): array
 	{
+		if ($node->isOpaque()) {
+			return [];
+		}
+
 		$errors = [];
-		foreach ($node->init as $expr) {
-			if (!($expr instanceof Assign)) {
+		foreach ($node->getWrites() as $write) {
+			// only a for loop that takes over a variable assigned before the loop
+			// and read after it - reusing a spent loop variable is harmless
+			$loop = $node->getVariableOverwritingLoop($write);
+			if (!$loop instanceof For_) {
 				continue;
 			}
 
-			foreach ($this->checkValueVar($scope, $expr->var) as $error) {
-				$errors[] = $error;
-			}
-		}
-
-		return $errors;
-	}
-
-	/**
-	 * @return list<IdentifierRuleError>
-	 */
-	private function checkValueVar(Scope $scope, Expr $expr): array
-	{
-		$errors = [];
-		if (
-			$expr instanceof Node\Expr\Variable
-			&& is_string($expr->name)
-			&& $scope->hasVariableType($expr->name)->yes()
-		) {
-			$errors[] = RuleErrorBuilder::message(sprintf('For loop initial assignment overwrites variable $%s.', $expr->name))
+			$errors[] = RuleErrorBuilder::message(sprintf('For loop initial assignment overwrites variable $%s.', $write->getVariableName()))
 				->identifier('for.variableOverwrite')
+				->line($loop->getStartLine())
 				->build();
-		}
-
-		if (
-			$expr instanceof Node\Expr\List_
-			|| $expr instanceof Node\Expr\Array_
-		) {
-			foreach ($expr->items as $item) {
-				if ($item === null) {
-					continue;
-				}
-
-				foreach ($this->checkValueVar($scope, $item->value) as $error) {
-					$errors[] = $error;
-				}
-			}
 		}
 
 		return $errors;

--- a/src/Rules/ForeachLoop/OverwriteVariablesWithForeachRule.php
+++ b/src/Rules/ForeachLoop/OverwriteVariablesWithForeachRule.php
@@ -3,75 +3,49 @@
 namespace PHPStan\Rules\ForeachLoop;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt\Foreach_;
 use PHPStan\Analyser\Scope;
-use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Node\Variable\VariableWrite;
+use PHPStan\Node\VariableWritesNode;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use function is_string;
 use function sprintf;
 
 /**
- * @implements Rule<Foreach_>
+ * @implements Rule<VariableWritesNode>
  */
 class OverwriteVariablesWithForeachRule implements Rule
 {
 
 	public function getNodeType(): string
 	{
-		return Foreach_::class;
+		return VariableWritesNode::class;
 	}
 
 	public function processNode(Node $node, Scope $scope): array
 	{
+		if ($node->isOpaque()) {
+			return [];
+		}
+
 		$errors = [];
-		if (
-			$node->keyVar instanceof Node\Expr\Variable
-			&& is_string($node->keyVar->name)
-			&& $scope->hasVariableType($node->keyVar->name)->yes()
-		) {
-			$errors[] = RuleErrorBuilder::message(sprintf('Foreach overwrites $%s with its key variable.', $node->keyVar->name))
-				->identifier('foreach.keyOverwrite')
-				->build();
-		}
-
-		foreach ($this->checkValueVar($scope, $node->valueVar) as $error) {
-			$errors[] = $error;
-		}
-
-		return $errors;
-	}
-
-	/**
-	 * @return list<IdentifierRuleError>
-	 */
-	private function checkValueVar(Scope $scope, Expr $expr): array
-	{
-		$errors = [];
-		if (
-			$expr instanceof Node\Expr\Variable
-			&& is_string($expr->name)
-			&& $scope->hasVariableType($expr->name)->yes()
-		) {
-			$errors[] = RuleErrorBuilder::message(sprintf('Foreach overwrites $%s with its value variable.', $expr->name))
-				->identifier('foreach.valueOverwrite')
-				->build();
-		}
-
-		if (
-			$expr instanceof Node\Expr\List_
-			|| $expr instanceof Node\Expr\Array_
-		) {
-			foreach ($expr->items as $item) {
-				if ($item === null) {
-					continue;
-				}
-
-				foreach ($this->checkValueVar($scope, $item->value) as $error) {
-					$errors[] = $error;
-				}
+		foreach ($node->getWrites() as $write) {
+			// only a foreach that takes over a variable assigned before the loop
+			// and read after it - reusing a spent loop variable is harmless
+			$loop = $node->getVariableOverwritingLoop($write);
+			if (!$loop instanceof Foreach_) {
+				continue;
 			}
+
+			$isKey = $write->getKind() === VariableWrite::KIND_FOREACH_KEY;
+			$errors[] = RuleErrorBuilder::message(sprintf(
+				'Foreach overwrites $%s with its %s variable.',
+				$write->getVariableName(),
+				$isKey ? 'key' : 'value',
+			))
+				->identifier($isKey ? 'foreach.keyOverwrite' : 'foreach.valueOverwrite')
+				->line($loop->getStartLine())
+				->build();
 		}
 
 		return $errors;

--- a/tests/Rules/ForLoop/OverwriteVariablesWithForLoopInitRuleTest.php
+++ b/tests/Rules/ForLoop/OverwriteVariablesWithForLoopInitRuleTest.php
@@ -25,39 +25,61 @@ class OverwriteVariablesWithForLoopInitRuleTest extends RuleTestCase
 			],
 			[
 				'For loop initial assignment overwrites variable $i.',
-				20,
+				21,
 			],
 			[
 				'For loop initial assignment overwrites variable $j.',
-				20,
+				21,
 			],
 			[
 				'For loop initial assignment overwrites variable $i.',
-				24,
+				26,
 			],
 			[
 				'For loop initial assignment overwrites variable $i.',
-				35,
+				38,
 			],
 			[
 				'For loop initial assignment overwrites variable $j.',
-				35,
+				38,
 			],
 			[
 				'For loop initial assignment overwrites variable $i.',
-				39,
+				43,
 			],
 			[
 				'For loop initial assignment overwrites variable $j.',
-				39,
+				43,
 			],
 			[
 				'For loop initial assignment overwrites variable $i.',
-				50,
+				55,
 			],
 			[
 				'For loop initial assignment overwrites variable $i.',
-				54,
+				60,
+			],
+		]);
+	}
+
+	public function testLoopVariableReuse(): void
+	{
+		$this->analyse([__DIR__ . '/data/for-reuse.php'], [
+			[
+				'For loop initial assignment overwrites variable $i.',
+				61,
+			],
+			[
+				'For loop initial assignment overwrites variable $i.',
+				70,
+			],
+			[
+				'For loop initial assignment overwrites variable $i.',
+				78,
+			],
+			[
+				'For loop initial assignment overwrites variable $i.',
+				87,
 			],
 		]);
 	}

--- a/tests/Rules/ForLoop/data/data.php
+++ b/tests/Rules/ForLoop/data/data.php
@@ -13,6 +13,7 @@ class Foo{
 		for($j = 0; $j < 10; ++$j){
 
 		}
+		echo $i, $j;
 	}
 
 	public function multi(int $i, int $j): void
@@ -20,10 +21,12 @@ class Foo{
 		for($i = 0, $j = 0; $i < 10; ++$i){
 			
 		}
+		echo $i, $j;
 
 		for($i = 0, $k = 0; $i < 10; ++$i){
 
 		}
+		echo $i, $k;
 
 		for($k = 0, $l = 0; $k < 10; ++$k){
 
@@ -35,10 +38,12 @@ class Foo{
 		for(list($i, $j) = $b; $i < 10; ++$i){
 
 		}
+		echo $i, $j;
 
 		for(list($i, list($j, $k)) = $b; $i < 10; ++$i){
 
 		}
+		echo $i, $j;
 
 		for(list($k, list($l, $m)) = $b; $k < 10; ++$k){
 
@@ -50,10 +55,12 @@ class Foo{
 		for([$i, $j] = $b; $i < 10; ++$i){
 
 		}
+		echo $i, $j;
 
 		for([$i, [$j, $k]] = $b; $i < 10; ++$i){
 
 		}
+		echo $i;
 
 		for([$k, [$l, $m]] = $b; $k < 10; ++$k){
 

--- a/tests/Rules/ForLoop/data/for-reuse.php
+++ b/tests/Rules/ForLoop/data/for-reuse.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace OverwriteVariablesWithForLoopInitReuse;
+
+class Foo
+{
+
+	public function sequentialLoops(): void
+	{
+		for ($i = 0; $i < 10; $i++) {
+			echo $i;
+		}
+		for ($i = 0; $i < 5; $i++) {
+			echo $i;
+		}
+	}
+
+	public function definednessProvedByFlag(int $n): void
+	{
+		$found = false;
+		for ($i = 0; $i < $n; $i++) {
+			if ($i === 3) {
+				$found = true;
+				break;
+			}
+		}
+		if (!$found) {
+			return;
+		}
+
+		for ($i = 0; $i < $n; $i++) {
+			echo $i;
+		}
+	}
+
+	public function parameterNotReadAfterLoop(int $i): void
+	{
+		echo $i;
+		for ($i = 0; $i < 10; $i++) {
+			echo $i;
+		}
+	}
+
+	public function freshVariableReadAfterLoop(): void
+	{
+		for ($i = 0; $i < 10; $i++) {
+		}
+		echo $i;
+	}
+
+	public function reassignedAfterLoop(int $i): void
+	{
+		for ($i = 0; $i < 10; $i++) {
+		}
+		$i = 5;
+		echo $i;
+	}
+
+	public function parameterReadAfterLoop(int $i): void
+	{
+		for ($i = 0; $i < 10; $i++) {
+		}
+		echo $i;
+	}
+
+	public function loopVariableReadAfterSecondLoop(): void
+	{
+		for ($i = 0; $i < 10; $i++) {
+		}
+		for ($i = 0; $i < 5; $i++) {
+		}
+		echo $i;
+	}
+
+	public function outerLoopVariableClobbered(): void
+	{
+		for ($i = 0; $i < 10; $i++) {
+			for ($i = 0; $i < 5; $i++) {
+			}
+			echo $i;
+		}
+	}
+
+	/** @param array{int, int} $b */
+	public function listTarget(int $i, int $j, array $b): void
+	{
+		for ([$i, $j] = $b; $i < 10; $i++) {
+		}
+		echo $i;
+	}
+
+}

--- a/tests/Rules/ForeachLoop/OverwriteVariablesWithForeachRuleTest.php
+++ b/tests/Rules/ForeachLoop/OverwriteVariablesWithForeachRuleTest.php
@@ -25,25 +25,48 @@ class OverwriteVariablesWithForeachRuleTest extends RuleTestCase
 			],
 			[
 				'Foreach overwrites $b with its value variable.',
-				26,
+				27,
 			],
 			[
 				'Foreach overwrites $d with its value variable.',
-				26,
+				27,
 			],
 			[
 				'Foreach overwrites $b with its value variable.',
-				32,
+				34,
 			],
 			[
 				'Foreach overwrites $d with its value variable.',
-				32,
+				34,
 			],
 			[
 				'Foreach overwrites $b with its key variable.',
-				38,
+				41,
 			],
 		]);
+	}
+
+	public function testLoopVariableReuse(): void
+	{
+		$this->analyse([__DIR__ . '/data/foreach-reuse.php'], [
+			[
+				'Foreach overwrites $x with its value variable.',
+				86,
+			],
+			[
+				'Foreach overwrites $x with its value variable.',
+				99,
+			],
+			[
+				'Foreach overwrites $x with its value variable.',
+				110,
+			],
+		]);
+	}
+
+	public function testBug9940(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-9940.php'], []);
 	}
 
 }

--- a/tests/Rules/ForeachLoop/data/bug-9940.php
+++ b/tests/Rules/ForeachLoop/data/bug-9940.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace Bug9940;
+
+class HelloWorld
+{
+	public function checkQuery(): void
+	{
+		$queryStrings = [];
+		foreach (doSomething() as $queryString) {
+			$queryStrings[] = $queryString;
+		}
+
+		if ($queryStrings === []) {
+			return;
+		}
+
+		foreach ($queryStrings as $queryString) {
+		}
+	}
+}
+
+/** @return array<string> */
+function doSomething():array {
+	return [];
+}

--- a/tests/Rules/ForeachLoop/data/foreach-reuse.php
+++ b/tests/Rules/ForeachLoop/data/foreach-reuse.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace OverwriteVariablesWithForeachReuse;
+
+class Foo
+{
+
+	/**
+	 * @param string[] $a
+	 * @param string[] $b
+	 */
+	public function sequentialLoops(array $a, array $b): void
+	{
+		foreach ($a as $x) {
+			echo $x;
+		}
+		foreach ($b as $x) {
+			echo $x;
+		}
+		foreach ($b as $k => $x) {
+			echo $k, $x;
+		}
+		foreach ($b as $k => $x) {
+			echo $k, $x;
+		}
+	}
+
+	/**
+	 * @param string[] $catches
+	 * @param string[] $exceptions
+	 */
+	public function definednessProvedByFlag(array $catches, array $exceptions): void
+	{
+		$hasGeneralCatch = false;
+		foreach ($catches as $catch) {
+			if ($catch === 'x') {
+				$hasGeneralCatch = true;
+				break;
+			}
+		}
+		if (!$hasGeneralCatch) {
+			return;
+		}
+
+		foreach ($exceptions as $exception) {
+			foreach ($catches as $catch) {
+				echo $exception, $catch;
+			}
+		}
+	}
+
+	/** @param string[] $a */
+	public function notReadAfterLoop(array $a, string $x): void
+	{
+		echo $x;
+		foreach ($a as $x) {
+			echo $x;
+		}
+	}
+
+	/** @param string[] $a */
+	public function freshVariableReadAfterLoop(array $a): void
+	{
+		foreach ($a as $x) {
+		}
+		echo $x;
+	}
+
+	/** @param string[] $a */
+	public function reassignedAfterLoop(array $a, string $x): void
+	{
+		echo $x;
+		foreach ($a as $x) {
+		}
+		$x = 'other';
+		echo $x;
+	}
+
+	/**
+	 * @param string[] $outer
+	 * @param string[] $inner
+	 */
+	public function outerLoopVariableClobbered(array $outer, array $inner): void
+	{
+		foreach ($outer as $x) {
+			foreach ($inner as $x) {
+				echo $x;
+			}
+			echo $x;
+		}
+	}
+
+	/** @param string[] $a */
+	public function conditionallyAssignedBeforeLoop(array $a, bool $c): void
+	{
+		if ($c) {
+			$x = 'default';
+		}
+		foreach ($a as $x) {
+		}
+		echo $x;
+	}
+
+	/** @param string[] $a */
+	public function readInLaterIterationOfOuterLoop(array $outer, array $a): void
+	{
+		$x = 'initial';
+		foreach ($outer as $o) {
+			echo $o, $x;
+			foreach ($a as $x) {
+			}
+		}
+	}
+
+}

--- a/tests/Rules/ForeachLoop/data/foreach.php
+++ b/tests/Rules/ForeachLoop/data/foreach.php
@@ -14,6 +14,7 @@ class Foo
 		foreach ($a as $str) {
 
 		}
+		echo $str;
 
 		foreach ($a as $val) {
 			foreach ($b as $var) {
@@ -26,12 +27,14 @@ class Foo
 		foreach ($a as [$b, $c, [$d, $e]]) {
 
 		}
+		echo $b, $d;
 	}
 
 	public function doBaz(array $a, string $b, string $d) {
 		foreach ($a as list($b, $c, list($d, $e))) {
 
 		}
+		echo $b, $d;
 	}
 
 	public function doLorem(array $a, string $b) {
@@ -41,6 +44,7 @@ class Foo
 		foreach ($a as $c => $val) {
 
 		}
+		echo $b, $c;
 	}
 
 }


### PR DESCRIPTION
Closes #332, fixes phpstan/phpstan#9940. Requires phpstan/phpstan-src#6414 (merged, in the current 2.3.x dev phar).

`OverwriteVariablesWithForeachRule` and `OverwriteVariablesWithForLoopInitRule` now listen on `VariableWritesNode` and report a foreach key/value binding or a for-loop initial assignment only when `getVariableOverwritingLoop()` returns the loop: the variable was assigned before the loop **and** is read after it, with no assignment in between other than the loop's own bindings and updates. Reusing a spent loop variable is silent, including the flag-then-check pattern from #332 and the #9940 reproducer.

Behaviour changes beyond the issue:
- A conditionally assigned variable before the loop (`if ($c) { $x = 1; }`) now reports when `$x` is read after the loop; it was `Maybe` and silent before. The old value genuinely survives an empty loop there.
- Top-level script code is no longer checked, since `VariableWritesNode` is emitted per function-like, same as phpstan-src's dead-code rules.
- The for-loop rule reports `for ($i = 0; ...)` over an existing `$i` only when `$i` is read after the loop.

Existing fixtures keep every original error (reads were added after the loops); new fixtures show the silent cases and the positive contrasts (nested loop clobbering an outer loop variable, read in a later iteration of an outer loop, list targets).

The static analysis job needs phpstan/phpstan-src#6415 (`@api` on the two classes) in the dev phar; tests and coding standards pass with the current one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYiPGg9cpsKLyK6X5BrJTT